### PR TITLE
add version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ compilation
  * fortran77/90 compiler, e.g. gfortran or ifort
  * NetCDF (netcdf > 4.1.1)
  * NetCDF-fortran
-
+ * Python3 (optional)
+ * git (optional)
 
 
 ## Installation
@@ -58,6 +59,13 @@ bsnap_naccident snap.input
 ```
 
 Examples of `snap.input` can be found in the directory [src/naccident/examples/](src/naccident/examples).
+
+### Versioning
+
+The build system uses automatic versioning based on git tags and revision numbers and embeds this into the resulting program. If git or python3 is unavailable, this logic should be bypassed by setting the environment variable VERSION to some value, e.g.
+```sh
+env VERSION="some_version_number" make install
+```
 
 
 ## License

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,6 @@
 SUBDIRS = naccident nbomb traj volcano
-GIT_VERSION ?= git.$(shell git rev-parse --verify --short HEAD)
-# Version from environment, fall back on commit hash
-VERSION ?= $(GIT_VERSION)
+# Version from environment, fall back on git versions
+VERSION ?= $(shell ./version.py)
 export VERSION
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,17 +1,18 @@
 SUBDIRS = naccident nbomb traj volcano
-# version from environment
-VERSION ?= "1.0"
+GIT_VERSION ?= git.$(shell git rev-parse --verify --short HEAD)
+# Version from environment, fall back on commit hash
+VERSION ?= $(GIT_VERSION)
+export VERSION
+
 
 all:
 	for i in $(SUBDIRS); do \
-		cd $$i && $(MAKE); \
-		cd ..; \
+		$(MAKE) -C $$i; \
 	done
 
 clean:
 	for i in $(SUBDIRS); do \
-		cd $$i && $(MAKE) clean; \
-		cd ..; \
+		$(MAKE) -C $$i clean; \
 	done
 
 dist: clean
@@ -22,18 +23,15 @@ dist: clean
 
 install:
 	for i in $(SUBDIRS); do \
-		cd $$i && $(MAKE) install; \
-		cd ..; \
+		$(MAKE) -C $$i install; \
 	done
 
 naccident_install:
 	for i in naccident; do \
-		cd $$i && $(MAKE) install; \
-		cd ..; \
+		$(MAKE) -C $$i install; \
 	done
 
 nbomb_install:
 	for i in nbomb; do \
-		cd $$i && $(MAKE) install; \
-		cd ..; \
+		$(MAKE) -C $$i install; \
 	done

--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -207,7 +207,7 @@
 
 
 PROGRAM bsnap
-  USE iso_fortran_env, only: real64, error_unit
+  USE iso_fortran_env, only: real64, output_unit, error_unit
   USE DateCalc  ,ONLY : epochToDate, timeGM
   USE snapdebug, only: iulog, idebug
   USE snapargosML
@@ -361,6 +361,14 @@ PROGRAM bsnap
     stop 1
   endif
   call get_command_argument(1, finput)
+  if (finput == "--version") then
+#if defined(VERSION)
+    write(output_unit,*) "snap version: ", VERSION
+#else
+    write(output_unit,*) "snap version: UNVERSIONED"
+#endif
+    stop
+  endif
 
   iuinp=8
   open(iuinp,file=finput, &

--- a/src/ubuntuBionic.mk
+++ b/src/ubuntuBionic.mk
@@ -13,7 +13,7 @@ CC  = gcc
 #F77FLAGS=-O2 -g -mavx -ffpe-trap=invalid,zero,overflow -fbounds-check -Wall
 #-DPETTERSEN
 # -ffpe-trap=invalid,zero,overflow no longer usable, conflict/bug in gfortran with IEEE_VALUE(IEEE_QUIET_NAN)
-F77FLAGS=-O2 -ftree-vectorize -fno-math-errno -g -mavx -fopt-info-optimized-vec -fopenmp $(PROFILE) -Wall -Wextra -fimplicit-none -fmodule-private -std=gnu -Wuse-without-only
+F77FLAGS=-DVERSION=\"$(VERSION)\" -O2 -ftree-vectorize -fno-math-errno -g -mavx -fopt-info-optimized-vec -fopenmp $(PROFILE) -Wall -Wextra -fimplicit-none -fmodule-private -std=gnu -Wuse-without-only
 CXXFLAGS=-O3 $(PROFILE) -Wall -Wextra
 CCFLAGS=-O3 -g $(PROFILE) -Wall -Wextra
 
@@ -47,4 +47,3 @@ BLIBS += $(MILIB) -lnetcdff
 
 # clear out all suffixes
 .SUFFIXES:
-

--- a/src/ubuntuLucid.mk
+++ b/src/ubuntuLucid.mk
@@ -5,7 +5,7 @@ F77 = gfortran
 CXX = g++
 CC  = gcc
 
-F77FLAGS=-O3 -Wall -Wextra -fimplicit-none -fmodule-private
+F77FLAGS=-DVERSION=\"$(VERSION)\" -O3 -Wall -Wextra -fimplicit-none -fmodule-private
 CXXFLAGS=-O3 -Wall -Wextra
 CCFLAGS=-O3 -Wall -Wextra
 

--- a/src/ubuntuLustre.mk
+++ b/src/ubuntuLustre.mk
@@ -9,7 +9,7 @@ CC  = gcc
 #      -ftree-vectorizer-verbose=2
 #-ffpe-trap=invalid,zero,overflow
 #F77FLAGS=-O2 -g -ftree-vectorize -fno-math-errno -ffpe-trap=invalid,zero,overflow -g -mavx -fopt-info-optimized-vec #-fopenmp
-F77FLAGS=-O2 -g -msse2 -Wall -Wextra -fimplicit-none -fmodule-private
+F77FLAGS=-DVERSION=\"$(VERSION)\" -O2 -g -msse2 -Wall -Wextra -fimplicit-none -fmodule-private
 CXXFLAGS=-O2 -mavx -ftree-vectorize -fno-math-errno -Wall -Wextra
 CCFLAGS=-O2 -mavx -ftree-vectorize -fno-math-errno -Wall -Wextra
 

--- a/src/ubuntuLustreIntel.mk
+++ b/src/ubuntuLustreIntel.mk
@@ -5,7 +5,7 @@ F77 = ifort
 CXX = icc
 CC  = icc
 
-F77FLAGS=-O2 -qopenmp -warn all
+F77FLAGS=-DVERSION=\"$(VERSION)\" -O2 -qopenmp -warn all
 CXXFLAGS=-O2 -qopenmp
 CCFLAGS=-O2 -qopenmp
 

--- a/src/ubuntuLustreSnappy.mk
+++ b/src/ubuntuLustreSnappy.mk
@@ -9,7 +9,7 @@ CC  = gcc
 #      -ftree-vectorizer-verbose=2
 #-ffpe-trap=invalid,zero,overflow
 #F77FLAGS=-O2 -g -msse2 -ffpe-trap=invalid,zero,overflow
-F77FLAGS=-O2 -g -mavx -ftree-vectorize -fno-math-errno -Wall -Wextra -fimplicit-none -fmodule-private
+F77FLAGS=-DVERSION=\"$(VERSION)\" -O2 -g -mavx -ftree-vectorize -fno-math-errno -Wall -Wextra -fimplicit-none -fmodule-private
 CXXFLAGS=-O2 -mavx -ftree-vectorize -fno-math-errno -Wall -Wextra
 CCFLAGS=-O2 -mavx -ftree-vectorize -fno-math-errno -Wall -Wextra
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,0 +1,80 @@
+#! /usr/bin/env python3
+from subprocess import check_output, DEVNULL
+import sys
+
+
+def git_dirty():
+    """
+    Checks whether we are on a dirty git directory, which may
+    contain unwanted artifacts or uncommited items
+    """
+    git_status = check_output(["git", "status", "--porcelain"])
+    dirty = git_status != b''
+    return dirty
+
+
+def git_tags():
+    """
+    Gets the latest git tag that points at current HEAD
+    """
+    git_tags = check_output(["git", "tag", "--points-at"])
+    tags = git_tags.decode("utf-8").splitlines()
+    return tags
+
+
+def git_hash(short_hash=True):
+    """
+    Gets the latest git hash
+    """
+    command = ["git", "rev-parse", "--verify", "HEAD"]
+    if short_hash:
+        command.append("--short")
+    output = check_output(command)
+
+    return output.decode("utf-8").strip()
+
+
+def git_tag_remote_consistent(tag, commithash):
+    """
+    Checks the remote for tags, to ensure the local tags have been
+    pushed to remote.
+    """
+    # stderr contains the "From ..." line, which we ignore
+    output = check_output(["git", "ls-remote", "--tags"], stderr=DEVNULL)
+    output = output.decode("utf-8").splitlines()
+
+    for line in output:
+        tagcommit, taghash = line.split()
+        if taghash == "refs/tags/" + tag and tagcommit == commithash:
+            return True
+    return False
+
+
+if __name__ == "__main__":
+    if git_dirty():
+        print("The current directory is (git) dirty", file=sys.stderr)
+        print("git.DIRTY")
+        exit(1)
+
+    tags = git_tags()
+    if len(tags) == 0:
+        commithash = git_hash()
+        print("git.hash.{}".format(commithash))
+        exit(1)
+
+    if len(tags) == 2:
+        print("More than one tag detected, using tag {}".format(tags[0]),
+              file=sys.stderr)
+
+    commithash = git_hash(short_hash=False)
+    remote_consistent = git_tag_remote_consistent(tags[0], commithash)
+    if not remote_consistent:
+        # Local tag not consistent with remote tag
+        print("Tag was not found on the remote server matching the local hash",
+              file=sys.stderr)
+
+        print("git.BADTAG+git.hash.{}".format(git_hash()))
+        exit(1)
+
+    print(tags[0])
+    exit(0)

--- a/src/version.py
+++ b/src/version.py
@@ -30,7 +30,7 @@ def git_tags():
     """
     Gets the latest git tag that points at current HEAD
     """
-    git_tags = check_output(["git", "tag", "--points-at"])
+    git_tags = check_output(["git", "tag", "--points-at", "HEAD"])
     tags = git_tags.decode("utf-8").splitlines()
     return tags
 


### PR DESCRIPTION
This pull request adds a runtime check for the version of snap currently in use. This can be invoked with e.g.
```
bsnap_naccident --version
```

This falls back on the git hash if VERSION is not given as environment variable
Currently gives an empty version when building from the subdirectories

Should we refine this approach, or document that releases must be created from the src directory?