### PR TITLE
Changed bug in run directory (swapped hour/minute)

### DIFF
--- a/utils/SnapPy/snapRemoteRunner.py
+++ b/utils/SnapPy/snapRemoteRunner.py
@@ -103,7 +103,7 @@ class SnapTask():
         top_rundir = os.path.join(self.topdir, SnapRemoteRunner.RUN_DIR)
         if not os.path.isdir(top_rundir):
             os.mkdir(top_rundir)
-        self.rundir = os.path.join(top_rundir, "{dt}_{ident}".format(dt=self.timestamp.strftime('%Y-%m-%dT%M%H%S'),
+        self.rundir = os.path.join(top_rundir, "{dt}_{ident}".format(dt=self.timestamp.strftime('%Y-%m-%dT%H%M%S'),
                                                                      ident=self.id))
         os.mkdir(self.rundir)
         infile = os.path.join(self.topdir, SnapRemoteRunner.UPLOAD_DIR, self.zipfile)


### PR DESCRIPTION
This changes output directory from 
'%Y-%m-%dT%M%H%S', i.e., YYYY-MM-DDTMMHHSS (note minutes and hours)
to
'%Y-%m-%dT%H%M%S', i.e., YYYY-MM-DDTHHMMSS
