### PR TITLE
Added fix for 23+ km eruptions

### DIFF
--- a/utils/SnapPy/Snappy/BrowserWidget.py
+++ b/utils/SnapPy/Snappy/BrowserWidget.py
@@ -24,12 +24,20 @@
     *******************************************************************
 """
 
-from PyQt5 import QtCore, QtWidgets, QtWebKitWidgets
+from PyQt5 import QtCore, QtWidgets
+try:
+    #Qt5.5 and earlier
+    from PyQt5.QtWebKitWidgets import QWebPage, QWebView
+except:
+    #Qt5.6 and later - QtWebKitWidgets is deprecated
+    from PyQt5.QtWebEngineWidgets import QWebEnginePage as QWebPage
+    from PyQt5.QtWebEngineWidgets import QWebEngineView as QWebView
+    
 from builtins import str
 import sys
 
 
-class StartWebPage(QtWebKitWidgets.QWebPage):
+class StartWebPage(QWebPage):
     formSubmitted = QtCore.pyqtSignal(QtCore.QUrl)
 
     def __init__(self):
@@ -55,7 +63,7 @@ class BrowserWidget(QtWidgets.QWidget):
         self.layout = QtWidgets.QHBoxLayout()
         self.setLayout(self.layout)
 
-        self.webview = QtWebKitWidgets.QWebView()
+        self.webview = QWebView()
         self.layout.addWidget(self.webview)
 
         self.webview.urlChanged.connect(self.url_changed)
@@ -69,7 +77,7 @@ class BrowserWidget(QtWidgets.QWidget):
     def browse(self):
         """browse an url"""
         url = self.tb_url.text() if self.tb_url.text() else self.default_url
-        self.webview.setPage(QtWebKitWidgets.QWebPage())
+        self.webview.setPage(QWebPage())
         self.webview.load(QtCore.QUrl(url))
         self.webview.show()
 

--- a/utils/SnapPy/Snappy/BrowserWidget.py
+++ b/utils/SnapPy/Snappy/BrowserWidget.py
@@ -24,14 +24,23 @@
     *******************************************************************
 """
 
-from PyQt5 import QtCore, QtWidgets
-try:
-    #Qt5.5 and earlier
-    from PyQt5.QtWebKitWidgets import QWebPage, QWebView
-except:
+
+#Get Qt version 
+from PyQt5 import Qt
+qt_version = [ int(v) for v in Qt.QT_VERSION_STR.split('.') ]
+
+#Import correct parts of Qt
+if (qt_version[0] >= 5 and qt_version[1] >= 6):
     #Qt5.6 and later - QtWebKitWidgets is deprecated
+    from PyQt5 import QtCore, QtWidgets
     from PyQt5.QtWebEngineWidgets import QWebEnginePage as QWebPage
     from PyQt5.QtWebEngineWidgets import QWebEngineView as QWebView
+elif (qt_version[0] >= 5):
+    #Qt5.5 and earlier
+    from PyQt5 import QtCore, QtWidgets
+    from PyQt5.QtWebKitWidgets import QWebPage, QWebView
+else:
+    raise ImportError("Unsupported version of PyQt")
     
 from builtins import str
 import sys

--- a/utils/SnapPy/Snappy/EEMEP/Controller.py
+++ b/utils/SnapPy/Snappy/EEMEP/Controller.py
@@ -234,6 +234,16 @@ class Controller():
                 # rate in kg/s from Mastin et al. 2009, formular (1) and a volume (DRE) (m3) to
                 # mass (kg) density of 2500kg/m3
                 rate = 2500.* ((.5*cheight/1000)**(1/0.241))
+                
+                # eEMEP runs up-to 23 km, so remove all ash above 23 km,
+                # See Varsling av vulkanaske i norsk luftrom - driftsfase, 
+                # February 2020 for details
+                eemep_cheight_asl_max = 23000.0
+                cheight_asl = cheight+altf
+                if (cheight_asl > eemep_cheight_asl_max):
+                    debug("Cropping ash cloud to 23 km ASL from {:.0f} km".format(cheight_asl/1000.0))
+                    rate = rate * (eemep_cheight_asl_max / cheight_asl)
+                    cheight = eemep_cheight_asl_max - altf
         except:
             errors += "cannot interpret cloudheight (m): {0}\n".format(qDict['cloudheight'])
 

--- a/utils/SnapPy/Snappy/EEMEP/Controller.py
+++ b/utils/SnapPy/Snappy/EEMEP/Controller.py
@@ -236,6 +236,18 @@ class Controller():
                 rate = 2500.* ((.5*cheight/1000)**(1/0.241))
         except:
             errors += "cannot interpret cloudheight (m): {0}\n".format(qDict['cloudheight'])
+
+        # eEMEP runs up-to 23 km, so remove all ash above 23 km,
+        # See Varsling av vulkanaske i norsk luftrom - driftsfase, 
+        # February 2020 for details
+        eemep_cheight_max = 23000.0-altf
+        if (cheight > eemep_cheight_max):
+            debug("Cropping ash cloud to {:.0f} km ASL from {:.0f} km".format(eemep_cheight_max/1000.0, cheight/1000.0))
+            rate_fraction = eemep_cheight_max / cheight
+            debug("Ash reduction factor {:f}".format(rate_fraction))
+            rate = rate * rate_fraction
+            cheight = eemep_cheight_max
+
         eruptions = []
         eruption = '<eruption start="{start}Z" end="{end}Z" bottom="{bottom:.0f}" top="{top:.0f}" rate="{rate:.0f}" m63="{m63:.2f}"/>'
         eruptions.append(eruption.format(start=startDT.isoformat(),

--- a/utils/SnapPy/Snappy/EEMEP/resources/startScreenVolc.html
+++ b/utils/SnapPy/Snappy/EEMEP/resources/startScreenVolc.html
@@ -91,7 +91,7 @@ function toggle_advanced_sourceterm() {
        <!--  -->
        <label>Eruption Start UTC (YYYY-MM-DD HH:MM):<br><input name="startTime" type="text" value="%CURRENTTIME%" size="20" maxlength="20" ></label>
        <br><label>Run-Length (in hours)<br><input name="runTime" type="number" step="3" max="120" min="12" value="48"></label>
-       <br><label>Ash-Cloud (m over surface) if available<br><input name="cloudheight" type="number" step="500" max="16000" min="0"></label>
+       <br><label>Ash-Cloud (m above volcano vent) if available<br><input name="cloudheight" type="number" step="500" max="50000" min="0"></label>
        <br>
          <fieldset>
          <legend><a href="javascript: toggle_advanced_sourceterm()">Advanced</a></legend>
@@ -125,7 +125,7 @@ function toggle_advanced_sourceterm() {
        If <b>Use Lat-Lon</b>:<br>
        <span title="e.g. 60.15, 60:2:3N, 60°2'3 N"><label>Latitude: &nbsp;&nbsp;<input name="latitude" type="text" size="8" maxlength="10"></label></span><br>
        <span title="e.g. 10.15, 10:2:3E, 10°2'03 E"><label>Longitude: <input name="longitude" type="text" size="8" maxlength="10"></label></span><br>
-       <label>Altitude (m) (e.g. 3300): <input name="altitude" type="number" step="1" max="9000" min="0"></label>
+       <label>Vent altitude (m ASL) (e.g. 3300): <input name="altitude" type="number" step="1" max="9000" min="0"></label>
        </fieldset>
      </fieldset>
      </div>


### PR DESCRIPTION
A few fixes in this PR, the most important is automatic handling of 23+ km ASL eruptions
- 23+ km above sea level eruptions are truncated to 23 km above sea level (removing ash above 23 km)
- QtWebKitWidgets is deprecated. Added automatic loading of new classes. 
- Slight updates to GUI to emphasize above sea level / above vent