### PR TITLE
bugfixes

### DIFF
--- a/src/common/readfield_fi.f90
+++ b/src/common/readfield_fi.f90
@@ -539,7 +539,7 @@ contains
     use iso_fortran_env, only: error_unit
     use snapdebug, only: iulog
     use snapmetML, only: met_params, &
-                         precip_rate_units, precip_units
+                         precip_rate_units, precip_units_ => precip_units, precip_units_fallback
     use snapfldML, only: field1, field2, field3, field4, precip, &
                          enspos, precip, nprecip
     use snapdimML, only: nx, ny
@@ -556,6 +556,8 @@ contains
     integer :: i, j, nr
     real :: precip1
     real :: totalprec
+    character(len=10), save :: precip_units = precip_units_
+    integer :: ierror
 
 !.. get the correct ensemble/realization position, nr starting with 1, enspos starting with 0
     nr = enspos + 1
@@ -578,33 +580,32 @@ contains
     else if (met_params%precstratiaccumv /= '') then
       ! accumulated stratiform and convective precipitation
       !..precipitation between input time 't1' and 't2'
+      call fi_checkload(fio, met_params%precstratiaccumv, precip_units, field3(:, :), nt=timepos, nr=nr, ierror=ierror)
+      if (ierror /= 0) then
+        !> There was an error, try reading using a fallback precip unit
+        precip_units = precip_units_fallback
+        call fi_checkload(fio, met_params%precstratiaccumv, precip_units, field3(:, :), nt=timepos, nr=nr)
+      endif
+      call fi_checkload(fio, met_params%precconaccumv, precip_units, field4(:, :), nt=timepos, nr=nr)
+
       if (timepos /= 1) then
-        call fi_checkload(fio, met_params%precstratiaccumv, "mm", field1(:, :), nt=timeposm1, nr=nr, nz=1)
-        call fi_checkload(fio, met_params%precconaccumv, "mm", field2(:, :), nt=timeposm1, nr=nr, nz=1)
-        call fi_checkload(fio, met_params%precstratiaccumv, "mm", field3(:, :), nt=timepos, nr=nr, nz=1)
-        call fi_checkload(fio, met_params%precconaccumv, "mm", field4(:, :), nt=timepos, nr=nr, nz=1)
-
-        do i = 1, nprecip
-          precip(:, :, i) = max(field3 + field4 - (field1 + field2), 0.0)/nhdiff
-        enddo
+        call fi_checkload(fio, met_params%precstratiaccumv, precip_units, field1(:, :), nt=timeposm1, nr=nr)
+        call fi_checkload(fio, met_params%precconaccumv, precip_units, field2(:, :), nt=timeposm1, nr=nr)
       else
-        ! timepos eq 1, check if precipitation already present / assume dummy step 0
-        call fi_checkload(fio, met_params%precstratiaccumv, "mm", field3(:, :), nt=timepos, nr=nr, nz=1)
-        call fi_checkload(fio, met_params%precconaccumv, "mm", field4(:, :), nt=timepos, nr=nr, nz=1)
-
         field1 = 0.0
         field2 = 0.0
-        totalprec = sum(field3) + sum(field4)
 
+        totalprec = sum(field3) + sum(field4)
         if (totalprec > 1e-5) then
-          !..the difference below may get negative due to different scaling
           write (iulog, *) "found precip in first timestep, assuming ", &
             "empty 0 timestep to deaccumulate precip"
-          do i = 1, nprecip
-            precip(:,:, i) = max(field3 + field4 - (field1 + field2), 0.0)/nhdiff
-          enddo
         endif
-      end if
+      endif
+
+      do i = 1, nprecip
+        precip(:, :, i) = max(field3 + field4 - (field1 + field2), 0.0)/nhdiff
+      enddo
+
     else if (met_params%total_column_rain /= '') then
       call fi_checkload(fio, met_params%total_column_rain, precip_units, field3(:, :), nt=timepos, nr=nr, nz=1)
       do j = 1, ny
@@ -647,7 +648,7 @@ contains
     endif
   end subroutine check
 
-  subroutine fi_checkload1d(fio, varname, units, field, nt, nz, nr)
+  subroutine fi_checkload1d(fio, varname, units, field, nt, nz, nr, ierror)
     !> the fimex io-object
     TYPE(FimexIO), intent(inout) :: fio
     !> variable name in file
@@ -660,6 +661,8 @@ contains
     integer, intent(in), optional :: nt
     !> optional position on realization/ensemble axis, default 1
     integer, intent(in), optional :: nr
+    !> error code, 0 on success
+    integer, intent(out), optional :: ierror
     !> field to read
     real(real32), intent(out) :: field(:)
 
@@ -671,36 +674,38 @@ contains
     deallocate(zfield)
   end subroutine fi_checkload1d
 
-  subroutine fi_checkload2d(fio, varname, units, field, nt, nz, nr)
+  subroutine fi_checkload2d(fio, varname, units, field, nt, nz, nr, ierror)
     TYPE(FimexIO), intent(inout) :: fio
     character(len=*), intent(in) :: varname, units
     integer, intent(in), optional :: nt, nz, nr
     real(real32), intent(out) :: field(:, :)
+    integer, intent(out), optional :: ierror
 
     real(kind=real64), dimension(:), allocatable, target :: zfield
 
-    call fi_checkload_intern(fio, varname, units, zfield, nt, nz, nr)
+    call fi_checkload_intern(fio, varname, units, zfield, nt, nz, nr, ierror)
 
     field(:,:) = reshape(zfield, shape(field))
     deallocate(zfield)
   end subroutine fi_checkload2d
 
-  subroutine fi_checkload3d(fio, varname, units, field, nt, nz, nr)
+  subroutine fi_checkload3d(fio, varname, units, field, nt, nz, nr, ierror)
     TYPE(FimexIO), intent(inout) :: fio
     character(len=*), intent(in) :: varname, units
     integer, intent(in), optional :: nt, nz, nr
     real(real32), intent(out) :: field(:, :, :)
+    integer, intent(out), optional :: ierror
 
     real(kind=real64), dimension(:), allocatable, target :: zfield
 
-    call fi_checkload_intern(fio, varname, units, zfield, nt, nz, nr)
+    call fi_checkload_intern(fio, varname, units, zfield, nt, nz, nr, ierror)
 
     field(:,:,:) = reshape(zfield, shape(field))
     deallocate(zfield)
   end subroutine fi_checkload3d
 
   !> internal implementation, allocating the zfield
-  subroutine fi_checkload_intern(fio, varname, units, zfield, nt, nz, nr)
+  subroutine fi_checkload_intern(fio, varname, units, zfield, nt, nz, nr, ierror)
     USE Fimex, ONLY: FimexIO, AXIS_GeoX, AXIS_GeoY, AXIS_Lon, AXIS_Lat, AXIS_GeoZ, &
                      AXIS_Pressure, AXIS_Height, AXIS_Realization, AXIS_Time
     USE utils, ONLY: itoa
@@ -710,9 +715,16 @@ contains
     character(len=*), intent(in) :: varname, units
     integer, intent(in), optional :: nt, nz, nr
     real(kind=real64), dimension(:), allocatable, target, intent(out) :: zfield
+    !> Error code, 0 for no error
+    integer, intent(out), optional :: ierror
 
     integer(int32), dimension(:), allocatable :: start, length, atypes
     integer(int32) :: tlength, i, ndims
+    integer :: ierr
+
+    if (present(ierror)) then
+      ierror = 0
+    endif
 
 ! Get dimensions
     ndims = fio%get_dimensions(varname)
@@ -760,7 +772,13 @@ contains
     allocate (zfield(tlength))
     write (iulog, *) "reading "//trim(varname)//", dims: ", "start(0):", start, " size:", length, " total-size:", tlength
     if (units /= "") then
-      call check(fio%read (varName, zfield, units), "reading '"//varname//"' in unit '"//units//"'")
+      ierr = fio%read(varName, zfield, units)
+      if (.not.present(ierror)) then
+        call check(ierr, "reading '"//varname//"' in unit '"//units//"'")
+      else
+        ierror = ierr
+        return
+      endif
     else
       call check(fio%read (varName, zfield), "reading '"//varname//"'")
     end if

--- a/src/common/readfield_fi.f90
+++ b/src/common/readfield_fi.f90
@@ -297,8 +297,8 @@ contains
       call fi_checkload(fio, met_params%xwind10mv, xy_wind_units, u2(:, :, 1), nt=timepos, nr=nr, nz=1)
       call fi_checkload(fio, met_params%ywind10mv, xy_wind_units, v2(:, :, 1), nt=timepos, nr=nr, nz=1)
     else
-      call fi_checkload(fio, met_params%xwindv, xy_wind_units, u2(:, :, 1), nt=timepos, nr=nr, nz=1)
-      call fi_checkload(fio, met_params%ywindv, xy_wind_units, v2(:, :, 1), nt=timepos, nr=nr, nz=1)
+      call fi_checkload(fio, met_params%xwindv, xy_wind_units, u2(:, :, 1), nt=timepos, nr=nr, nz=nk)
+      call fi_checkload(fio, met_params%ywindv, xy_wind_units, v2(:, :, 1), nt=timepos, nr=nr, nz=nk)
     endif
 
 !..mean sea level pressure, not used in computations,

--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -887,7 +887,10 @@ PROGRAM bsnap
         if (idrydep == 2) call drydep2(tstep, pdata(np))
 
         !..wet deposition (1=old, 2=new version)
-        if (wetdep_version == 2) call wetdep2(tstep, pdata(np), pextra)
+        block
+        use snapfldML, only: depwet
+        if (wetdep_version == 2) call wetdep2(depwet, tstep, pdata(np), pextra)
+        end block
 
         !..move all particles forward, save u and v to pextra
         call forwrd(tf1, tf2, tnow, tstep, pdata(np), pextra)

--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -256,7 +256,7 @@ PROGRAM bsnap
   logical :: init = .TRUE.
 
   character(len=1024) ::  finput, fldfil = "snap.dat", fldfilX, fldfilN, logfile = "snap.log", ftype = "felt", &
-                         fldtype = "felt", relfile = "*", fimex_config, fimex_type
+                         fldtype = "felt", relfile = "*", fimex_config = "", fimex_type = ""
   character(len=1024) :: tempstr
 
 !> name of selected release position

--- a/src/common/snapmetML.f90
+++ b/src/common/snapmetML.f90
@@ -64,6 +64,9 @@ module snapmetML
   character(len=*), parameter, public :: omega_units = 'Pa/s'
   character(len=*), parameter, public :: precip_rate_units = 'mm/hr' ! kg/m2/s
   character(len=*), parameter, public :: precip_units = 'kg/m2'
+  !> Equivalency to `precip_units`, and scaling between the two =>
+  !> precip_units / density of water = (kg / m^2) / (1000 kg/m^3) = 1 / 1000 m = mm
+  character(len=*), parameter, public :: precip_units_fallback = 'mm'
   character(len=*), parameter, public :: temp_units = 'K'
 
 

--- a/src/common/wetdep.f90
+++ b/src/common/wetdep.f90
@@ -30,11 +30,13 @@ module wetdep
 !> NOTE: ::wetdep2_init must be run first
 !>
 !> Method:   J.Bartnicki 2003
-subroutine wetdep2(tstep, part, pextra)
+pure subroutine wetdep2(depwet, tstep, part, pextra)
+  USE iso_fortran_env, only: real64
   USE particleML, only: Particle, extraParticle
-  USE snapfldML, only: depwet
   USE snapparML, only: def_comp, run_comp
 
+!> Field which ret deposition gets added to
+  real(real64), intent(inout) :: depwet(:,:,:)
 !> Timestep of the simulation, affects the deposition rate
   real, intent(in) :: tstep
 !> particle

--- a/src/common/wetdep.f90
+++ b/src/common/wetdep.f90
@@ -21,8 +21,7 @@ module wetdep
 
   public wetdep2, wetdep2_init
 
-  contains
-
+contains
 
 !> Purpose:  Compute wet deposition for each particle and each component
 !>           and store depositions in nearest gridpoint in a field
@@ -30,132 +29,133 @@ module wetdep
 !> NOTE: ::wetdep2_init must be run first
 !>
 !> Method:   J.Bartnicki 2003
-pure subroutine wetdep2(depwet, tstep, part, pextra)
-  USE iso_fortran_env, only: real64
-  USE particleML, only: Particle, extraParticle
-  USE snapparML, only: def_comp, run_comp
+  pure subroutine wetdep2(depwet, tstep, part, pextra)
+    USE iso_fortran_env, only: real64
+    USE particleML, only: Particle, extraParticle
+    USE snapparML, only: def_comp, run_comp
 
 !> Field which ret deposition gets added to
-  real(real64), intent(inout) :: depwet(:,:,:)
+    real(real64), intent(inout) :: depwet(:, :, :)
 !> Timestep of the simulation, affects the deposition rate
-  real, intent(in) :: tstep
+    real, intent(in) :: tstep
 !> particle
-  type(Particle), intent(inout) :: part
+    type(Particle), intent(inout) :: part
 !> uses the precipitation at the particle position
-  type(extraParticle), intent(in) :: pextra
+    type(extraParticle), intent(in) :: pextra
 
-  integer :: m,i,j,mm
-  real :: precint,deprate,dep,q
+    integer :: m, i, j, mm
+    real :: precint, deprate, dep, q
 
+    m = part%icomp
+    if (def_comp(m)%kwetdep == 1 .AND. pextra%prc > 0.0 &
+        .AND. part%z > 0.67) then
+      !..find particles with wet deposition and
+      !..reset precipitation to zero if not wet deposition
+      precint = pextra%prc
+      q = precint
 
-  m = part%icomp
-  if(def_comp(m)%kwetdep == 1 .AND. pextra%prc > 0.0 &
-      .AND. part%z > 0.67) then
-  !..find particles with wet deposition and
-  !..reset precipitation to zero if not wet deposition
-    precint = pextra%prc
-    q = precint
+      mm = def_comp(m)%to_running
 
-    mm = def_comp(m)%to_running
+      deprate = wet_deposition_rate(def_comp(m)%radiusmym, q, run_comp(mm)%depconst, tstep)
 
-    deprate = wet_deposition_rate(def_comp(m)%radiusmym, q, run_comp(mm)%depconst, tstep)
+      ! b... 25.04.12 wet deposition for convective and gases
+      dep = deprate*part%rad
+      if (dep > part%rad) dep = part%rad
+      part%rad = part%rad - dep
+      i = nint(part%x)
+      j = nint(part%y)
+      mm = def_comp(m)%to_running
 
-  ! b... 25.04.12 wet deposition for convective and gases
-    dep = deprate*part%rad
-    if(dep > part%rad) dep = part%rad
-    part%rad = part%rad-dep
-    i = nint(part%x)
-    j = nint(part%y)
-    mm = def_comp(m)%to_running
-
-  ! omp atomic
-    depwet(i,j,mm) = depwet(i,j,mm) + dble(dep)
-  end if
-end subroutine wetdep2
+      ! omp atomic
+      depwet(i, j, mm) = depwet(i, j, mm) + dble(dep)
+    end if
+  end subroutine wetdep2
 
 !> Initialisation routine for ::wetdep2
-subroutine wetdep2_init(tstep)
+  subroutine wetdep2_init(tstep)
 ! initalization
-  USE snapdebug, only: iulog
-  USE particleML, only: Particle, extraParticle
-  USE snapparML, only: ncomp
-  USE snapparML, only: run_comp, def_comp
+    USE snapdebug, only: iulog
+    USE particleML, only: Particle, extraParticle
+    USE snapparML, only: ncomp
+    USE snapparML, only: run_comp, def_comp
 
 !> Timestep in seconds
-  real, intent(in) :: tstep
+    real, intent(in) :: tstep
 
-  integer :: m, n, mm
-  real :: q
+    integer :: m, n, mm
+    real :: q
 
-  real, allocatable :: ratdep(:)
-  real :: rm
+    real, allocatable :: ratdep(:)
+    real :: rm
 
-  allocate(ratdep(ncomp))
+    allocate (ratdep(ncomp))
 
-  do m=1,ncomp
-    mm = run_comp(m)%to_defined
-    rm = def_comp(mm)%radiusmym
-    run_comp(m)%depconst = wet_deposition_constant(rm)
-    write(iulog,*) 'WETDEP2 m,r,depconst(m): ',m,rm,run_comp(m)%depconst
-  end do
-
-  write(iulog,*) '-------------------------------------------------'
-  write(iulog,*) 'WETDEP2 PREPARE .... q,deprate(1:ncomp):'
-
-  do n=1,200
-    q=float(n)*0.1
-    do m=1,ncomp
+    do m = 1, ncomp
       mm = run_comp(m)%to_defined
-      ratdep(m) = wet_deposition_rate(def_comp(mm)%radiusmym, q, run_comp(m)%depconst, tstep)
+      rm = def_comp(mm)%radiusmym
+      run_comp(m)%depconst = wet_deposition_constant(rm)
+      write (iulog, *) 'WETDEP2 m,r,depconst(m): ', m, rm, run_comp(m)%depconst
     end do
-    write(iulog,1010) q,(ratdep(m),m=1,ncomp)
-1010 format(1x,f5.1,':',12f7.4)
-  end do
-  write(iulog,*) '-------------------------------------------------'
-end subroutine
 
-pure real function wet_deposition_constant(rm) result(depconst)
+    write (iulog, *) '-------------------------------------------------'
+    write (iulog, *) 'WETDEP2 PREPARE .... q,deprate(1:ncomp):'
+
+    do n = 1, 200
+      q = float(n)*0.1
+      do m = 1, ncomp
+        mm = run_comp(m)%to_defined
+        ratdep(m) = wet_deposition_rate(def_comp(mm)%radiusmym, q, run_comp(m)%depconst, tstep)
+      end do
+      write (iulog, 1010) q, (ratdep(m), m=1, ncomp)
+1010  format(1x, f5.1, ':', 12f7.4)
+    end do
+    write (iulog, *) '-------------------------------------------------'
+  end subroutine
+
+  pure real function wet_deposition_constant(rm) result(depconst)
 !> Radius in micrometer
-  real, intent(in) :: rm
+    real, intent(in) :: rm
 
-  real, parameter :: b0 = -0.1483
-  real, parameter :: b1 = 0.3220133
-  real, parameter :: b2 = -3.0062e-2
-  real, parameter :: b3 = 9.34458e-4
+    real, parameter :: b0 = -0.1483
+    real, parameter :: b1 = 0.3220133
+    real, parameter :: b2 = -3.0062e-2
+    real, parameter :: b3 = 9.34458e-4
 
-  depconst = b0 + b1*rm + b2*rm*rm + b3*rm*rm*rm
-end function
+    depconst = b0 + b1*rm + b2*rm*rm + b3*rm*rm*rm
+  end function
 
-pure real function wet_deposition_rate(radius, q, depconst, tstep) result(deprate)
-! ... 23.04.12 - gas, particle 0.1<d<10, particle d>10 - J. Bartnicki|
-! ... 12.12.13 - gas 'particle size' changed to 0.05um - H. Klein
-  real, intent(in) :: radius
-  real, intent(in) :: q
-  real, intent(in) :: depconst
-  real, intent(in) :: tstep
+  pure real function wet_deposition_rate(radius, q, depconst, tstep) result(deprate)
+    !> radius in micrometer
+    real, intent(in) :: radius
+    !> precipitation intensity in mm/h
+    real, intent(in) :: q
+    !> deposition constant
+    real, intent(in) :: depconst
+    !> length of a timestep in hours
+    real, intent(in) :: tstep
 
-  real, parameter :: a0 = 8.4e-5
-  real, parameter :: a1 = 2.7e-4
-  real, parameter :: a2 = -3.618e-6
+    real, parameter :: a0 = 8.4e-5
+    real, parameter :: a1 = 2.7e-4
+    real, parameter :: a2 = -3.618e-6
 
-  real :: rkw
+    real :: rkw
 
-  rkw = 0
-  if(radius > 0.05 .AND. radius <= 1.4) then
-    rkw = a0*q**0.79
-  endif
-  if(radius > 1.4 .AND. radius <= 10.0) then
-    rkw = depconst*(a1*q + a2*q*q)
-  endif
-  if(radius > 10.0) then
-    rkw = a1*q + a2*q*q
-  endif
-  if(q > 7.0) then ! convective
-    rkw = 3.36e-4*q**0.79
-  endif
-  if(radius <= 0.1) then ! gas
-    rkw = 1.12e-4*q**0.79
-  endif
-  deprate = 1.0 - exp(-tstep*rkw)
-end function
+    rkw = 0
+    if (radius > 0.05 .AND. radius <= 1.4) then
+      rkw = a0*q**0.79
+    endif
+    if (radius > 1.4 .AND. radius <= 10.0) then
+      rkw = depconst*(a1*q + a2*q*q)
+    endif
+    if (radius > 10.0) then
+      rkw = a1*q + a2*q*q
+    endif
+    if (q > 7.0) then ! convective
+      rkw = 3.36e-4*q**0.79
+    endif
+    if (radius <= 0.1) then ! gas
+      rkw = 1.12e-4*q**0.79
+    endif
+    deprate = 1.0 - exp(-tstep*rkw)
+  end function
 end module wetdep


### PR DESCRIPTION
The fimex backend would try to read some precipitation fields which did not have compatible units, so it will now read `mm` units.

The fimex backend would read from level=0 when reading 10m fields, getting ground winds from the top of the atmosphere, instead of the bottom.