### PR TITLE
proj to rotated longlat

### DIFF
--- a/src/common/find_parameters_fi.f90
+++ b/src/common/find_parameters_fi.f90
@@ -79,7 +79,7 @@ contains
     stat = 0
     stat = fio%open (file, config, type)
     if (stat /= 0) then
-      write (error_unit, *) "Can't make io-object with file:"//trim(file)//" config: "//config
+      write (error_unit, *) "Can't make io-object with file: "//trim(file)//" config: "//trim(config)
       return
     endif
 

--- a/src/common/find_parameters_fi.f90
+++ b/src/common/find_parameters_fi.f90
@@ -224,6 +224,7 @@ contains
         stat = ERROR_THIS_MODULE
         return
       endif
+      ! No projection of longitude is required
       gparam(5) = atof(pval)
 
       pval = proj_arg(proj4, "o_lat_p")
@@ -234,8 +235,8 @@ contains
       gparam(6) = atof(pval)
 
       igtype = SPHERICAL_ROTATED
-      gparam(5) = 180 + gparam(5) ! need equator projection
-      gparam(6) = 0 + 90 - gparam(6) ! need equator projection
+      ! Projection from pole to equator
+      gparam(6) = 0 + 90 - gparam(6)
     endif
 
     ! Getting the longitude oriented gparams

--- a/src/common/find_parameters_fi.f90
+++ b/src/common/find_parameters_fi.f90
@@ -128,6 +128,9 @@ contains
     case ("lcc")
       call lambert_grid(fio, varname, proj4, nx, ny, xdim, ydim, igtype, gparam, stat)
 
+    case ("ob_tran")
+      call geographic_grid(fio, proj4, nx, ny, xdim, ydim, igtype, gparam, rotated=.true., stat=stat)
+
     case default
       write (error_unit, *) "This projection type is lacking a grid mapping: ", TRIM(proj_arg(proj4, 'proj'))
       stat = ERROR_THIS_MODULE
@@ -210,9 +213,27 @@ contains
       igtype = GEOGRAPHIC
       gparam(5:6) = 0
     else
+      pval = proj_arg(proj4, "o_proj")
+      if (pval /= "longlat") then
+        stat = ERROR_THIS_MODULE
+        return
+      endif
+
+      pval = proj_arg(proj4, "lon_0")
+      if (pval == "") then
+        stat = ERROR_THIS_MODULE
+        return
+      endif
+      gparam(5) = atof(pval)
+
+      pval = proj_arg(proj4, "o_lat_p")
+      if (pval == "") then
+        stat = ERROR_THIS_MODULE
+        return
+      endif
+      gparam(6) = atof(pval)
+
       igtype = SPHERICAL_ROTATED
-      stat = ERROR_THIS_MODULE
-      if (stat /= 0) return
       gparam(5) = 180 + gparam(5) ! need equator projection
       gparam(6) = 0 + 90 - gparam(6) ! need equator projection
     endif

--- a/src/ubuntuBionic.mk
+++ b/src/ubuntuBionic.mk
@@ -26,7 +26,7 @@ NCDIR = /usr
 # pkg-config --cflags fimex
 # pkg-config --libs fimex
 #FIMEXINC = -I/usr/include/fimex-1.4 # included fimex.f90
-FIMEXLIB = -lfimex-1.4 # -lfimexf-1.4 -lfimex-1.4
+FIMEXLIB = -lfimex-1.5 # -lfimexf-1.4 -lfimex-1.4
 
 MIINC = -I/usr/include
 MILIB_FLAGS = -fno-implicit-none -fno-module-private -Wno-all -Wno-extra


### PR DESCRIPTION
The SLIM files contains a rotated lat-lon grid, which we has not been tested with the automatic parameter finding. This PR adds the necessary parsing of the proj string to convert to `gparam`