### PR TITLE
ensure nctype is set before autodetection

### DIFF
--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -1967,6 +1967,10 @@ contains
           write (error_unit, *) "grid.autodetect requires at least one field.input to be set"
           goto 12
         endif
+        if (nctype == "*") then
+          write (error_unit, *) "grid.autodetect requires an nctype to be set"
+          goto 12
+        endif
         if (ftype .eq. "fimex") then
 #ifdef FIMEX
           call detect_gridparams_fi(filef(1), fimex_config, fimex_type, met_params%xwindv, nx, ny, igtype, gparam, klevel, ierror)


### PR DESCRIPTION
Error case previously lead to probing for a variable called "" (empty), with a confusing error message