### PR TITLE
Autodetection of libraries

### DIFF
--- a/src/COMPILE.md
+++ b/src/COMPILE.md
@@ -1,6 +1,7 @@
 # Compilation guide to SNAP
 
-This codebase uses makefiles for compilation. To use the correct template for your platform, link or copy the `*.mk` most appropriate to your platform to `current.mk`.
+This codebase uses makefiles for compilation. To use the correct template for your platform, link or copy the `*.mk` most appropriate to your platform to `current.mk`. It is reccommended to start by modifying `gcc_pkgconfig.mk` for autodetection of necessary libraries.
+
 
 ## Features
 

--- a/src/gcc_pkgconfig.mk
+++ b/src/gcc_pkgconfig.mk
@@ -1,0 +1,27 @@
+# link this to current.mk and it will be used in the Makefiles in subdirectories
+# includefile contains Compiler definitions etc.
+
+F77 = gfortran
+
+F77FLAGS=-DVERSION=\"$(VERSION)\" -O2 -ftree-vectorize -fno-math-errno -g -mavx2 -mfma -fopt-info-optimized-vec -Wall -Wextra -fimplicit-none -fmodule-private
+
+FIMEXLIB = $(shell pkg-config --libs fimex)
+FIMEXINC =
+
+NETCDFLIB = $(shell nf-config --flibs)
+NETCDFINC = $(shell nf-config --fflags)
+
+MILIB_FLAGS = -fno-implicit-none -fno-module-private -Wno-all -Wno-extra
+
+BINDIR=../../bin/
+
+INCLUDES =
+
+BLIBS += $(NETCDFLIB)
+BLIBS += $(FIMEXLIB)
+
+INCLUDES += $(NETCDFINC)
+INCLUDES += $(FIMEXINC)
+
+.SUFFIXES:
+


### PR DESCRIPTION
Adds a minimal makefile configuration which uses `pkg-config ` and `nf-config` to add libraries. This makes it easier to use for platforms which supports these methods for overriding the installed library.