### PR TITLE
Component time tracking

### DIFF
--- a/src/common/fldout_nc.f90
+++ b/src/common/fldout_nc.f90
@@ -939,7 +939,7 @@ subroutine nc_declare_3d(iunit, dimids, varid, &
 
   if (.false.) write (error_unit,*) chksz ! Silence compiler
 
-  write(iulog,*) "declaring ", iunit, TRIM(varnm), TRIM(units), &
+  write(iulog,*) "declaring ", TRIM(varnm), TRIM(units), &
       TRIM(stdnm),TRIM(metnm)
   call check(nf90_def_var(iunit, TRIM(varnm), &
       NF90_FLOAT, dimids, varid), "def_"//varnm)
@@ -966,7 +966,7 @@ subroutine nc_declare_4d(iunit, dimids, varid, &
   INTEGER, INTENT(IN)    :: iunit, dimids(4), chksz(4)
   CHARACTER(LEN=*), INTENT(IN) :: varnm, stdnm, metnm, units
 
-  write(iulog,*) "declaring ", iunit, TRIM(varnm), TRIM(units), &
+  write(iulog,*) "declaring ", TRIM(varnm), TRIM(units), &
       TRIM(stdnm),TRIM(metnm)
   call check(nf90_def_var(iunit, TRIM(varnm), &
       NF90_FLOAT, dimids, varid), "def_"//varnm)

--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -785,6 +785,7 @@ PROGRAM bsnap
           nxtinf = 1
           ifldout = 0
           ! continue istep loop after initialization
+          call timeloop_timer%stop()
           cycle time_loop
         end if
 

--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -265,10 +265,6 @@ PROGRAM bsnap
   type(acc_timer) :: input_timer
   type(acc_timer) :: particleloop_timer
 
-
-  character(len=8) :: date
-  character(len=10) :: time
-
 #if defined(TRAJ)
   integer :: timeStart(6), timeCurrent(6)
   integer :: ilvl, k1, k2
@@ -684,8 +680,6 @@ PROGRAM bsnap
     time_loop: do istep = 0, nstep
       call timeloop_timer%start()
       write (iulog, *) 'istep,nplume,npart: ', istep, nplume, npart
-      call date_and_time(date=date, time=time)
-      write (iulog, *) "current time: ", date, ", ", time
       flush (iulog)
       if (mod(istep, nsteph) == 0) then
         write (error_unit, *) 'istep,nplume,npart: ', istep, nplume, npart

--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -674,7 +674,6 @@ PROGRAM bsnap
     time_loop: do istep = 0, nstep
 
       write (iulog, *) 'istep,nplume,npart: ', istep, nplume, npart
-      call timer%log("timer: time_loop: ")
       flush (iulog)
       if (mod(istep, nsteph) == 0) then
         write (error_unit, *) 'istep,nplume,npart: ', istep, nplume, npart
@@ -1125,6 +1124,7 @@ PROGRAM bsnap
         enddo
       endif
 #endif
+      call timer%log("timer: time_loop: ")
     end do time_loop
 #if defined(TRAJ)
     close (13)

--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -263,6 +263,8 @@ PROGRAM bsnap
   type(timer_t) :: timer
   !> Timer for checking short-lasting tasks
   type(timer_t) :: task_timer
+  character(len=8) :: date
+  character(len=10) :: time
 
 #if defined(TRAJ)
   integer :: timeStart(6), timeCurrent(6)
@@ -672,8 +674,9 @@ PROGRAM bsnap
     ! start time loop
     timer = timer_t()
     time_loop: do istep = 0, nstep
-
       write (iulog, *) 'istep,nplume,npart: ', istep, nplume, npart
+      call date_and_time(date=date, time=time)
+      write (iulog, *) "current time: ", date, ", ", time
       flush (iulog)
       if (mod(istep, nsteph) == 0) then
         write (error_unit, *) 'istep,nplume,npart: ', istep, nplume, npart

--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -259,7 +259,7 @@ PROGRAM bsnap
 !> name of selected release position
   character(len=40), save :: srelnam = "*"
 
-  !> Running timer since start of timeloop
+  !> Running time since start of timeloop
   type(timer_t) :: timer
   !> Timer for checking short-lasting tasks
   type(timer_t) :: task_timer
@@ -1206,7 +1206,7 @@ contains
 #if defined(FIMEX)
     use find_parameters_fi, only: detect_gridparams_fi
 #endif
-  
+
     !> Open file unit
     integer, intent(in) :: snapinput_unit
 

--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -674,7 +674,7 @@ PROGRAM bsnap
     time_loop: do istep = 0, nstep
 
       write (iulog, *) 'istep,nplume,npart: ', istep, nplume, npart
-      call timer%log("time_loop: ")
+      call timer%log("timer: time_loop: ")
       flush (iulog)
       if (mod(istep, nsteph) == 0) then
         write (error_unit, *) 'istep,nplume,npart: ', istep, nplume, npart
@@ -723,7 +723,7 @@ PROGRAM bsnap
           write (iulog, *) "igtype, gparam(8): ", igtype, gparam
         end if
         if (ierror /= 0) call snap_error_exit(iulog)
-        call task_timer%log("Reading MET input: ")
+        call task_timer%log("timer: Reading MET input: ")
 
         n = time_file(5)
         call vtime(time_file, ierr)
@@ -910,7 +910,7 @@ PROGRAM bsnap
         call checkDomain(pdata(np))
       end do part_do
       !$OMP END PARALLEL DO
-      call task_timer%log("Particle loop: ")
+      call task_timer%log("timer: Particle loop: ")
 
       !..remove inactive particles or without any mass left
       call rmpart(rmlimit)
@@ -1067,7 +1067,7 @@ PROGRAM bsnap
         endif
         if (ierror /= 0) call snap_error_exit(iulog)
       end if
-      call task_timer%log("output/accumulation: ")
+      call task_timer%log("timer: output/accumulation: ")
 
       if (isteph == 0 .AND. iprecip < nprecip) iprecip = iprecip + 1
 

--- a/src/common/snap.mk
+++ b/src/common/snap.mk
@@ -46,7 +46,7 @@ snapfldML.o: ../common/snapfldML.f90
 	${F77} -c $(F77FLAGS) $(INCLUDES) $<
 ftest.o: ../common/ftest.f90 snapdebugML.o
 	${F77} -c $(F77FLAGS) $(INCLUDES) $<
-snapdebugML.o: ../common/snapdebugML.f90
+snapdebugML.o: ../common/snapdebugML.F90
 	${F77} -c $(F77FLAGS) $(INCLUDES) $<
 snapgrdML.o: ../common/snapgrdML.f90
 	${F77} -c $(F77FLAGS) $(INCLUDES) $<

--- a/src/common/snapdebugML.F90
+++ b/src/common/snapdebugML.F90
@@ -172,7 +172,7 @@ module snapdebug
       integer :: h, m, s, ms
       call real_to_hms_ms(t, h, m, s, ms)
 
-      write(str,"(I3, a, I2, a, I2, a, I4)") h, ":", m, ":", s, ".", ms
+      write(str,"(I3, ':', I0.2, ':', I0.2, '.', I0.4)") h, m, s, ms
 
     end function
 
@@ -271,12 +271,12 @@ module snapdebug
 
 #if defined(_OPENMP)
       write(current_unit,*) GLOBAL_TIMER_PREFIX, trim(this%prefix), " ", &
-        trim(to_str(duration_sys)), " (sys) ", &
+        trim(to_str(duration_sys)), " (system clock) ", &
         trim(to_str(duration_cpu)), " (cpu) ", &
-        trim(to_str(duration_womp)), " (wtime)"
+        trim(to_str(duration_womp)), " (walltime)"
 #else
       write(current_unit,*) GLOBAL_TIMER_PREFIX, trim(this%prefix), " ", &
-        trim(to_str(duration_sys)), " (sys) ", &
+        trim(to_str(duration_sys)), " (system clock) ", &
         trim(to_str(duration_cpu)), " (cpu)"
 #endif
     end subroutine
@@ -293,15 +293,11 @@ module snapdebug
         current_unit = iulog
       endif
 
+      write(current_unit,*) GLOBAL_TIMER_PREFIX, GLOBAL_TIMER_TOTAL_PREFIX, trim(this%prefix)
+      write(current_unit,*) "    system clock: ", trim(to_str(this%total_sys))
+      write(current_unit,*) "    cpu:          ", trim(to_str(this%total_cpu))
 #if defined(_OPENMP)
-      write(current_unit,*) GLOBAL_TIMER_PREFIX, GLOBAL_TIMER_TOTAL_PREFIX, trim(this%prefix), " ", &
-        trim(to_str(this%total_sys)), " (sys) " , &
-        trim(to_str(this%total_cpu)), " (cpu) ", &
-        trim(to_str(this%total_womp)), " (wtime)"
-#else
-      write(current_unit,*) GLOBAL_TIMER_PREFIX, GLOBAL_TIMER_TOTAL_PREFIX, trim(this%prefix), " ", &
-        trim(to_str(this%total_sys)), " (sys) " , &
-        trim(to_str(this%total_cpu)), " (cpu)"
+      write(current_unit,*) "    walltime:     ", trim(to_str(this%total_womp))
 #endif
     end subroutine
 end module snapdebug

--- a/src/common/snapdebugML.F90
+++ b/src/common/snapdebugML.F90
@@ -32,7 +32,7 @@ module snapdebug
 
     character(len=*), parameter :: global_timer_prefix = "timer: "
     character(len=*), parameter :: global_timer_total_prefix = "Total: "
-    integer, parameter :: prefix_len = 40
+    integer, parameter :: prefix_len = 35
 
     type, public :: timer_cpu_t
       real :: innertime
@@ -261,11 +261,9 @@ module snapdebug
         current_unit = iulog
       endif
 
-      write(tmp_str,*) GLOBAL_TIMER_PREFIX, trim(this%prefix), " "
-
-      write(current_unit,*) tmp_str, &
-        trim(to_str(duration_wtime)), " (wall) ", &
-        trim(to_str(duration_cpu)), " (cpu)"
+      write(tmp_str,'(a,a)') GLOBAL_TIMER_PREFIX, trim(this%prefix)
+      write(current_unit,'(a,a," (wall) ",a," (cpu)")') tmp_str, &
+        trim(to_str(duration_wtime)), trim(to_str(duration_cpu))
     end subroutine
 
     subroutine prefixed_timer_print_accumulated(this, unit)
@@ -282,9 +280,9 @@ module snapdebug
       endif
 
       tmp_str = ""
-      write(tmp_str, *) GLOBAL_TIMER_PREFIX, GLOBAL_TIMER_TOTAL_PREFIX, trim(this%prefix), " "
+      write(tmp_str, '(a,a,a)') GLOBAL_TIMER_PREFIX, GLOBAL_TIMER_TOTAL_PREFIX, trim(this%prefix)
       ! Not trimming tmp-str gives lined-up times
-      write(current_unit,*) tmp_str, trim(to_str(this%total_wtime)), " (wall) ", &
-        trim(to_str(this%total_cpu)), " (cpu)"
+      write(current_unit,'(a,a," (wall) ",a," (cpu)")') tmp_str, &
+           trim(to_str(this%total_wtime)), trim(to_str(this%total_cpu))
     end subroutine
 end module snapdebug

--- a/src/common/snapdebugML.f90
+++ b/src/common/snapdebugML.f90
@@ -66,11 +66,20 @@ module snapdebug
 
     !> Gets current time since start and
     !> outputs elapsed time into the log
-    subroutine timer_log(this, prefix)
+    subroutine timer_log(this, prefix, unit)
       class(timer_t), intent(in) :: this
       character(len=*), intent(in), optional :: prefix
+      integer, intent(in), optional :: unit
+
       real :: now
       integer :: hours, minutes, seconds, milliseconds
+      integer current_unit
+
+      if (present(unit)) then
+        current_unit = unit
+      else
+        current_unit = iulog
+      endif
 
       now = this%now()
 
@@ -85,9 +94,9 @@ module snapdebug
 
       milliseconds = floor(now*1000)
       if (present(prefix)) then
-        write(iulog,"(a,I3,a,I2,a,I2,a,I4)") prefix, hours, ":", minutes, ":", seconds, ".", milliseconds
+        write(current_unit,"(a,I3,a,I2,a,I2,a,I4)") prefix, hours, ":", minutes, ":", seconds, ".", milliseconds
       else
-        write(iulog,"(a,I3,a,I2,a,I2,a,I3)") "ctime: ", hours, ":", minutes, ":", seconds, ".", milliseconds
+        write(current_unit,"(a,I3,a,I2,a,I2,a,I3)") "ctime: ", hours, ":", minutes, ":", seconds, ".", milliseconds
       endif
     end subroutine
 end module snapdebug

--- a/src/common/snapdebugML.f90
+++ b/src/common/snapdebugML.f90
@@ -135,7 +135,7 @@ module snapdebug
       integer :: h, m, s, ms
       call real_to_hms_ms(t, h, m, s, ms)
 
-      write(str, *) "(I3, a, I2, a, I2, a, I4)", h, ":", m, ":", s, ".", ms
+      write(str,"(I3, a, I2, a, I2, a, I4)") h, ":", m, ":", s, ".", ms
 
     end function
 

--- a/src/common/snapdebugML.f90
+++ b/src/common/snapdebugML.f90
@@ -234,7 +234,8 @@ module snapdebug
         current_unit = iulog
       endif
 
-      write(current_unit,*) GLOBAL_TIMER_PREFIX, GLOBAL_TIMER_TOTAL_PREFIX, trim(this%prefix), &
-        " sys: ", trim(to_str(this%total_sys)), " cpu: ", trim(to_str(this%total_cpu))
+      write(current_unit,*) GLOBAL_TIMER_PREFIX, GLOBAL_TIMER_TOTAL_PREFIX, trim(this%prefix), " ", &
+        trim(to_str(this%total_sys)), " (sys) " , &
+        trim(to_str(this%total_cpu)), " (cpu)"
     end subroutine
 end module snapdebug

--- a/src/common/wetdep.f90
+++ b/src/common/wetdep.f90
@@ -29,7 +29,7 @@ contains
 !> NOTE: ::wetdep2_init must be run first
 !>
 !> Method:   J.Bartnicki 2003
-  pure subroutine wetdep2(depwet, tstep, part, pextra)
+  subroutine wetdep2(depwet, tstep, part, pextra)
     USE iso_fortran_env, only: real64
     USE particleML, only: Particle, extraParticle
     USE snapparML, only: def_comp, run_comp

--- a/utils/component_times_from_log.py
+++ b/utils/component_times_from_log.py
@@ -1,0 +1,108 @@
+#! /usr/bin/env python3
+import argparse
+import pathlib
+import matplotlib.pyplot as plt
+import matplotlib as mpl
+import numpy as np
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Outputs plots over time spent on the various computations for SNAP"
+    )
+    parser.add_argument("logfile", type=pathlib.Path)
+
+    args = parser.parse_args()
+    logfile = args.logfile
+
+    def timesplit(s: str):
+        hour, minute, rest = s.split(":")
+        second, ms = rest.split(".")
+
+        return int(hour) * 3600 + int(minute) * 60 + int(second) + int(ms) / 1000
+
+    isteps = []
+    nparts = []
+
+    output_time = []
+    timeloop = []
+    metinput_time = []
+    particleloop = []
+
+    with logfile.open("r") as f:
+        for line in f:
+            line = line.strip()
+            # Start of iteration
+            if line.startswith("istep,nplume,npart"):
+                _txt, istep, nplume, npart = line.split()
+                istep = int(istep)
+
+                if istep > 0:
+                    isteps.append(istep)
+                    nparts.append(int(npart))
+                    output_time.append(current_output_time)
+                    timeloop.append(current_timeloop_time)
+                    metinput_time.append(current_metinput_time)
+                    particleloop.append(current_particleloop_time)
+                    assert istep == len(output_time)
+
+                current_output_time = 0
+                current_timeloop_time = 0
+                current_metinput_time = 0
+                current_particleloop_time = 0
+            elif line.startswith("timer: output/accumulation:"):
+                line = line[len("timer: output/accumulation:") :]
+                current_output_time = timesplit(line)
+            elif line.startswith("timer: Reading MET input:"):
+                line = line[len("timer: Reading MET input:") :]
+                current_metinput_time = timesplit(line)
+            elif line.startswith("timer: Particle loop:"):
+                line = line[len("timer: Particle loop:") :]
+                current_particleloop_time = timesplit(line)
+            elif line.startswith("timer: time_loop:"):
+                line = line[len("timer: time_loop:") :]
+                current_timeloop_time = timesplit(line)
+
+    timeloop = np.array(timeloop)
+    particleloop = np.array(particleloop)
+    outputs = np.array(output_time)
+    met_input = np.array(metinput_time)
+    isteps = np.array(isteps)
+    nparts = np.array(nparts)
+
+    dtime = np.diff(timeloop)
+    dtime = np.hstack((timeloop[0], dtime))
+
+    fig = plt.figure()
+    gs = mpl.gridspec.GridSpec(2, 2)
+
+    ax2 = fig.add_subplot(gs[0, :])
+    ax2.stackplot(
+        isteps,
+        particleloop,
+        outputs,
+        met_input,
+        labels=["Particle loop", "accumulation/output", "MET input"],
+    )
+    ax2.plot(isteps, dtime, label="total time")
+    ax2.set_ylabel("Time per iteration [s]")
+    ax2.legend()
+    ax2.set_xlim((isteps[0], isteps[-1]))
+
+    ax3 = fig.add_subplot(gs[1, :])
+    factor = 1e6 / nparts
+    ax3.stackplot(
+        isteps,
+        particleloop * factor,
+        outputs * factor,
+        met_input * factor,
+        labels=["Particle loop", "accumulation/output", "MET input"],
+    )
+    dtimefac = dtime * factor
+    ax3.plot(isteps, dtime * factor, label="total time")
+    ax3.set_ylabel("Time per iteration per particle [µs]")
+    ax3.set_ylim([0, 2])
+    ax3.set_xlim((isteps[0], isteps[-1]))
+    ax3.legend()
+
+    plt.show()

--- a/utils/component_times_from_log.py
+++ b/utils/component_times_from_log.py
@@ -12,20 +12,20 @@ if __name__ == "__main__":
         description="Outputs plots over time spent on the various computations for SNAP"
     )
     parser.add_argument("logfile", type=pathlib.Path)
-    parser.add_argument("--mode", choices=["system_clock", "cpu", "wtime"], default="cpu")
+    parser.add_argument("--mode", choices=["wall", "cpu"], default="wall")
 
     args = parser.parse_args()
     logfile = args.logfile
 
-    treg = re.compile("\([\w ]+\)")
+    treg = re.compile("\(\w+\)")
 
     def timesplit(s: str):
-        sys, cpu, *rest = re.split(treg, s)
+        wall, cpu, *rest = re.split(treg, s)
         wtime = None
         if len(rest) > 1:
             wtime = rest.pop(0)
-        if args.mode == "system_clock":
-            t = sys
+        if args.mode == "wall":
+            t = wall
         elif args.mode == "cpu":
             t = cpu
         else:

--- a/utils/component_times_from_log.py
+++ b/utils/component_times_from_log.py
@@ -70,9 +70,6 @@ if __name__ == "__main__":
     isteps = np.array(isteps)
     nparts = np.array(nparts)
 
-    dtime = np.diff(timeloop)
-    dtime = np.hstack((timeloop[0], dtime))
-
     fig = plt.figure()
     gs = mpl.gridspec.GridSpec(2, 2)
 
@@ -84,7 +81,7 @@ if __name__ == "__main__":
         met_input,
         labels=["Particle loop", "accumulation/output", "MET input"],
     )
-    ax2.plot(isteps, dtime, label="total time")
+    ax2.plot(isteps, timeloop, label="total time")
     ax2.set_ylabel("Time per iteration [s]")
     ax2.legend()
     ax2.set_xlim((isteps[0], isteps[-1]))
@@ -98,8 +95,7 @@ if __name__ == "__main__":
         met_input * factor,
         labels=["Particle loop", "accumulation/output", "MET input"],
     )
-    dtimefac = dtime * factor
-    ax3.plot(isteps, dtime * factor, label="total time")
+    ax3.plot(isteps, timeloop * factor, label="total time")
     ax3.set_ylabel("Time per iteration per particle [µs]")
     ax3.set_ylim([0, 2])
     ax3.set_xlim((isteps[0], isteps[-1]))

--- a/utils/component_times_from_log.py
+++ b/utils/component_times_from_log.py
@@ -4,6 +4,7 @@ import pathlib
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 import numpy as np
+import re
 
 
 if __name__ == "__main__":
@@ -15,8 +16,11 @@ if __name__ == "__main__":
     args = parser.parse_args()
     logfile = args.logfile
 
+    treg = re.compile("\(\w+\)")
     def timesplit(s: str):
-        hour, minute, rest = s.split(":")
+        sys, cpu, _ = re.split(reg, s)
+
+        hour, minute, rest = sys.split(":")
         second, ms = rest.split(".")
 
         return int(hour) * 3600 + int(minute) * 60 + int(second) + int(ms) / 1000

--- a/utils/component_times_from_log.py
+++ b/utils/component_times_from_log.py
@@ -12,15 +12,26 @@ if __name__ == "__main__":
         description="Outputs plots over time spent on the various computations for SNAP"
     )
     parser.add_argument("logfile", type=pathlib.Path)
+    parser.add_argument("--mode", choices=["sys", "cpu", "wtime"], default="cpu")
 
     args = parser.parse_args()
     logfile = args.logfile
 
     treg = re.compile("\(\w+\)")
-    def timesplit(s: str):
-        sys, cpu, _ = re.split(reg, s)
 
-        hour, minute, rest = sys.split(":")
+    def timesplit(s: str):
+        sys, cpu, *rest = re.split(treg, s)
+        wtime = None
+        if len(rest) > 1:
+            wtime = rest.pop(0)
+        if args.mode == "sys":
+            t = sys
+        elif args.mode == "cpu":
+            t = cpu
+        else:
+            t = wtime
+
+        hour, minute, rest = t.split(":")
         second, ms = rest.split(".")
 
         return int(hour) * 3600 + int(minute) * 60 + int(second) + int(ms) / 1000

--- a/utils/component_times_from_log.py
+++ b/utils/component_times_from_log.py
@@ -12,19 +12,19 @@ if __name__ == "__main__":
         description="Outputs plots over time spent on the various computations for SNAP"
     )
     parser.add_argument("logfile", type=pathlib.Path)
-    parser.add_argument("--mode", choices=["sys", "cpu", "wtime"], default="cpu")
+    parser.add_argument("--mode", choices=["system_clock", "cpu", "wtime"], default="cpu")
 
     args = parser.parse_args()
     logfile = args.logfile
 
-    treg = re.compile("\(\w+\)")
+    treg = re.compile("\([\w ]+\)")
 
     def timesplit(s: str):
         sys, cpu, *rest = re.split(treg, s)
         wtime = None
         if len(rest) > 1:
             wtime = rest.pop(0)
-        if args.mode == "sys":
+        if args.mode == "system_clock":
             t = sys
         elif args.mode == "cpu":
             t = cpu


### PR DESCRIPTION
Adds timer functionality which is used to track the time spent on individual components of the SNAP model. The python script can be used to plot the time spent both per iteration and per (iteration, particle) during a run without requiring the model to finish execution