### PR TITLE
Fix releasefile

### DIFF
--- a/src/common/releasefile.f90
+++ b/src/common/releasefile.f90
@@ -78,10 +78,6 @@ subroutine  releasefile(filename, release1)
     if (cinput == "end") goto 18
     if (cinput(1:1) /= '*') then
       read(cinput, *, err=12) hour, height, comp, rel_s
-      if (lasthour == -1 .AND. hour /= 0) then
-        write (error_unit,*) 'first hour must be 0'
-        goto 12
-      end if
       if (hour < lasthour) then
         write (error_unit,*) 'hour must increase monotonic: ', &
         hour, ' < ', lasthour

--- a/src/common/releasefile.f90
+++ b/src/common/releasefile.f90
@@ -76,51 +76,53 @@ subroutine  releasefile(filename, release1)
     read(ifd,fmt='(a)',err=11) cinput
     if (debugrelfile) write (error_unit,*) 'cinput (',nlines,'):',cinput
     if (cinput == "end") goto 18
-    if (cinput(1:1) /= '*') then
-      read(cinput, *, err=12) hour, height, comp, rel_s
-      if (hour < lasthour) then
-        write (error_unit,*) 'hour must increase monotonic: ', &
-        hour, ' < ', lasthour
-        goto 12
-      end if
-      if (hour > lasthour) then
-      ! add new release timestep
-        lasthour = hour
-        ihour = ihour + 1
-        if (.not.allocated(releases)) then
-          allocate(releases(1))
-        else
-          call move_alloc(from=releases, to=tmp_release)
-          allocate(releases(size(tmp_release)+1))
-          releases(1:size(tmp_release)) = tmp_release
-          deallocate(tmp_release)
-        endif
-        releases(ihour)%frelhour = hour
-      ! make sure all initial release are undefined
-        releases(ihour)%relbqsec(:,:) = -1
-      end if
-    ! find the component
-      icmp = 0
-      do i=1,ncomp
-        if(comp == component(i)) icmp=i
-      end do
-      if (icmp == 0) then
-        write (error_unit,*) 'unknown component: ',comp
-        goto 12
-      endif
-    ! find the height
-      iheight = 0
-      do i=1,nrelheight
-        if(height == release1%rellower(i)) iheight = i
-      end do
-      if (iheight == 0) then
-        write (error_unit,*) 'unkown lower height: ', height
-        goto 12
-      end if
-    ! save the release
-      releases(ihour)%relbqsec(icmp, iheight) = rel_s
-    ! end ifnot comment '*'
+    if (cinput(1:1) == '*') cycle
+
+    read(cinput, *, err=12) hour, height, comp, rel_s
+    if (hour < lasthour) then
+      write (error_unit,*) 'hour must increase monotonic: ', &
+      hour, ' < ', lasthour
+      goto 12
     end if
+
+    if (hour > lasthour) then
+      ! add new release timestep
+      lasthour = hour
+      ihour = ihour + 1
+      if (.not.allocated(releases)) then
+        allocate(releases(1))
+      else
+        call move_alloc(from=releases, to=tmp_release)
+        allocate(releases(size(tmp_release)+1))
+        releases(1:size(tmp_release)) = tmp_release
+        deallocate(tmp_release)
+      endif
+      releases(ihour)%frelhour = hour
+      ! make sure all initial release are undefined
+      releases(ihour)%relbqsec(:,:) = -1
+    end if
+
+    ! find the component
+    icmp = 0
+    do i=1,ncomp
+      if(comp == component(i)) icmp=i
+    end do
+    if (icmp == 0) then
+      write (error_unit,*) 'unknown component: ',comp
+      goto 12
+    endif
+    ! find the height
+    iheight = 0
+    do i=1,nrelheight
+      if(height == release1%rellower(i)) iheight = i
+    end do
+    if (iheight == 0) then
+      write (error_unit,*) 'unkown lower height: ', height
+      goto 12
+    end if
+    ! save the release
+    releases(ihour)%relbqsec(icmp, iheight) = rel_s
+    ! end ifnot comment '*'
   end do
   goto 18
 

--- a/src/common/releasefile.f90
+++ b/src/common/releasefile.f90
@@ -30,7 +30,7 @@ module releasefileML
 !> data is read from the filename and modifies the fields of
 !> - releases
 subroutine  releasefile(filename, release1)
-  USE iso_fortran_env, only: error_unit
+  USE iso_fortran_env, only: error_unit, IOSTAT_END
   USE snapparML, only: ncomp, component
   USE snapdimML, only: mcomp
   USE releaseML, only: mrelheight, releases, nrelheight, release_t
@@ -40,7 +40,7 @@ subroutine  releasefile(filename, release1)
   type(release_t), intent(in) :: release1
 
   character(256) :: cinput
-  integer :: ifd, ios, iend, iexit, nlines
+  integer :: ifd, ios, iexit, nlines
   integer :: i,j
   real :: hour, lasthour
   integer :: height
@@ -68,12 +68,16 @@ subroutine  releasefile(filename, release1)
 
 ! header row
   nlines=0
-  iend=0
   lasthour = -1
   ihour = 0
-  inputlines: do while (iend == 0)
+  inputlines: do
     nlines=nlines+1
-    read(ifd,fmt='(a)',err=11) cinput
+    read(ifd, fmt='(a)', iostat=ios) cinput
+    if (ios == IOSTAT_END) then
+      exit inputlines
+    else if (ios /= 0) then
+      goto 11
+    endif
     if (debugrelfile) write (error_unit,*) 'cinput (',nlines,'):',cinput
     if (cinput == "end") exit inputlines
     if (cinput(1:1) == '*') cycle inputlines

--- a/src/common/releasefile.f90
+++ b/src/common/releasefile.f90
@@ -97,11 +97,7 @@ subroutine  releasefile(filename, release1)
         endif
         releases(ihour)%frelhour = hour
       ! make sure all initial release are undefined
-        do i=1,mcomp
-          do j=1,mrelheight
-            releases(ihour)%relbqsec(i,j)= -1.
-          end do
-        end do
+        releases(ihour)%relbqsec(:,:) = -1
       end if
     ! find the component
       icmp = 0

--- a/src/common/releasefile.f90
+++ b/src/common/releasefile.f90
@@ -27,11 +27,8 @@ module releasefileML
 !> comment-rows start with #
 !> hour height[upper_in_m] component release[kg/s]
 !>
-!> data is read to
-!> - frelhour
-!> - relbqsec(time, comp, height)
-!>
-!> for each release-step, rellower/relupper/relradius are copied from (1,x)
+!> data is read from the filename and modifies the fields of
+!> - releases
 subroutine  releasefile(filename, release1)
   USE iso_fortran_env, only: error_unit
   USE snapparML, only: ncomp, component
@@ -39,10 +36,10 @@ subroutine  releasefile(filename, release1)
   USE releaseML, only: mrelheight, releases, nrelheight, release_t
 
   character(72), intent(in) :: filename
+!> Structure to copy rellower, relupper, and relradius from
   type(release_t), intent(in) :: release1
 
   character(256) :: cinput
-  logical :: debugrelfile
   integer :: ifd, ios, iend, iexit, nlines
   integer :: i,j
   real :: hour, lasthour
@@ -53,7 +50,7 @@ subroutine  releasefile(filename, release1)
   integer :: ntprof
   type(release_t), allocatable :: tmp_release(:)
 
-  debugrelfile = .FALSE.
+  logical, parameter :: debugrelfile = .FALSE.
   iexit = 0
 
   write (error_unit,*) 'reading release from: ', filename
@@ -61,13 +58,12 @@ subroutine  releasefile(filename, release1)
     write (error_unit,*) 'ncomp, nrelheight', ncomp, nrelheight
   end if
 
-  ifd=8
-  open(ifd,file=filename, &
+  open(newunit=ifd,file=filename, &
       access='sequential',form='formatted', &
       status='old',iostat=ios)
   if(ios /= 0) then
     write (error_unit,*) 'Open Error: ', trim(filename)
-    stop 1
+    error stop 1
   endif
 
 ! header row

--- a/src/common/releasefile.f90
+++ b/src/common/releasefile.f90
@@ -71,12 +71,12 @@ subroutine  releasefile(filename, release1)
   iend=0
   lasthour = -1
   ihour = 0
-  do while (iend == 0)
+  inputlines: do while (iend == 0)
     nlines=nlines+1
     read(ifd,fmt='(a)',err=11) cinput
     if (debugrelfile) write (error_unit,*) 'cinput (',nlines,'):',cinput
-    if (cinput == "end") goto 18
-    if (cinput(1:1) == '*') cycle
+    if (cinput == "end") exit inputlines
+    if (cinput(1:1) == '*') cycle inputlines
 
     read(cinput, *, err=12) hour, height, comp, rel_s
     if (hour < lasthour) then
@@ -123,7 +123,7 @@ subroutine  releasefile(filename, release1)
     ! save the release
     releases(ihour)%relbqsec(icmp, iheight) = rel_s
     ! end ifnot comment '*'
-  end do
+  end do inputlines
   goto 18
 
   11 write (error_unit,*) 'ERROR reading file: ',filename(1:len(filename,1))
@@ -143,11 +143,9 @@ subroutine  releasefile(filename, release1)
 ! theoretically possible to add time-varying heights/radiuses
 ! but not supported by input file format yet
   do ihour=1,ntprof
-    do iheight=1,nrelheight
-      releases(ihour)%rellower(iheight) = release1%rellower(iheight)
-      releases(ihour)%relupper(iheight) = release1%relupper(iheight)
-      releases(ihour)%relradius(iheight) = release1%relradius(iheight)
-    end do
+    releases(ihour)%rellower(1:nrelheight) = release1%rellower(1:nrelheight)
+    releases(ihour)%relupper(1:nrelheight) = release1%relupper(1:nrelheight)
+    releases(ihour)%relradius(1:nrelheight) = release1%relradius(1:nrelheight)
   end do
 
 ! sanity check of relbqsec

--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -248,6 +248,7 @@ PROGRAM bsnap
 ! b_start
   real :: mhmin, mhmax  ! minimum and maximum of mixing height
 ! b_end
+!> Information for reading from a releasefile
   type(release_t) :: release1
 
   logical :: blfullmix = .true.

--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -1345,10 +1345,10 @@ contains
         kh = index(cinput(pname_start:pname_end), 'h')
         kd = index(cinput(pname_start:pname_end), 'd')
         if (kh > 0 .AND. kd == 0) then
-          read (cinput(pname_start:pname_start + kh), *, err=12) rnhrel
+          read (cinput(pname_start:pname_start + kh - 2), *, err=12) rnhrel
           nhrel = ceiling(rnhrel)
         elseif (kd > 0 .AND. kh == 0) then
-          read (cinput(pname_start:pname_start + kd), *, err=12) rnhrel
+          read (cinput(pname_start:pname_start + kd - 2), *, err=12) rnhrel
           nhrel = ceiling(rnhrel*24.)
         else
           goto 12

--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -1481,25 +1481,34 @@ contains
         !..release.radius.m
         if (.not. has_value) goto 12
         if (.not. allocated(releases)) call allocate_releases(cinput(pname_start:pname_end), ntprof)
-        read (cinput(pname_start:pname_end), *, err=12) releases%relradius(1)
+
+        call read_array_or_scalar(cinput(pname_start:pname_end), releases%relradius(1), ierror)
+        if (ierror /= 0) goto 12
         if (any(releases%relradius(1) < 0.0)) goto 12
+
       case ('release.upper.m')
         !..release.upper.m
         if (.not. has_value) goto 12
         if (.not. allocated(releases)) call allocate_releases(cinput(pname_start:pname_end), ntprof)
-        read (cinput(pname_start:pname_end), *, err=12) releases%relupper(1)
+        call read_array_or_scalar(cinput(pname_start:pname_end), releases%relupper(1), ierror)
+        if (ierror /= 0) goto 12
         if (any(releases%relupper(1) < 0.0)) goto 12
+
       case ('release.lower.m')
         !..release.lower.m
         if (.not. has_value) goto 12
         if (.not. allocated(releases)) call allocate_releases(cinput(pname_start:pname_end), ntprof)
-        read (cinput(pname_start:pname_end), *, err=12) releases%rellower(1)
+        call read_array_or_scalar(cinput(pname_start:pname_end), releases%rellower(1), ierror)
+        if (ierror /= 0) goto 12
         if (any(releases%rellower(1) < 0.0)) goto 12
+
       case ('release.mushroom.stem.radius.m')
         !..release.mushroom.stem.radius.m
         if (.not. has_value) goto 12
         if (.not. allocated(releases)) call allocate_releases(cinput(pname_start:pname_end), ntprof)
-        read (cinput(pname_start:pname_end), *, err=12) releases%relstemradius
+        call read_array_or_scalar(cinput(pname_start:pname_end), releases%relstemradius, ierror)
+        if (ierror /= 0) goto 12
+
       case ('release.bq/hour.comp', 'release.bq/sec.comp', 'release.bq/day.comp', 'release.bq/step.comp')
         !..release.bq/hour.comp
         !..release.bq/sec.comp
@@ -2361,5 +2370,22 @@ contains
     if (iprodr == 0) iprodr = iprod
     if (igridr == 0) igridr = igrid
 
+  end subroutine
+
+  ! Reads an array from str to arr, or broadcast a scalar
+  ! from str to arr
+  pure subroutine read_array_or_scalar(str, arr, stat)
+    character(len=*), intent(in) :: str
+    real, intent(out) :: arr(:)
+    integer, intent(out) :: stat
+
+    read (str, *, iostat=stat) arr
+    if (stat == 0) return
+    ! The IO error might be due to size mismatch, try reading a scalar
+    read (str, *, iostat=stat) arr(1)
+    if (stat /= 0) return
+
+    ! Broadcast the scalar to arr
+    arr(2:) = arr(1)
   end subroutine
 END PROGRAM

--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -336,6 +336,7 @@ PROGRAM bsnap
 
   if (relfile /= '*') then
     call releasefile(relfile, release1)
+    ntprof = size(releases)
   end if
 
 !..convert names to uppercase letters
@@ -2104,7 +2105,7 @@ contains
     nelems = nelems + 1 ! Fencepost
 
     allocate (releases(nelems))
-    do i = 1, ntprof
+    do i = 1, nelems
       releases(i)%frelhour = -1.0
       releases(i)%relradius = -1.0
       releases(i)%relupper = -1.0


### PR DESCRIPTION
Setting a release through the releasefile was currently broken, and has been fixed.

A new functionality has been added: `release.radius` and friends can now be specified as scalars instead of arrays, which should make specifying a fixed radius, upper, or lower release bound a bit friendlier.