### PR TITLE
Removed } from _MET_GLOBAL_INPUTDIRS for NrpaEC0p1Global

### DIFF
--- a/utils/SnapPy/Snappy/Resources.py
+++ b/utils/SnapPy/Snappy/Resources.py
@@ -66,7 +66,7 @@ class Resources:
 
     _MET_GLOBAL_INPUTDIRS = {
         MetModel.NrpaEC0p1Global: [
-            "{LUSTREDIR}}/project/metproduction/products/ecmwf/nc/"
+            "{LUSTREDIR}/project/metproduction/products/ecmwf/nc/"
         ],
         MetModel.Icon0p25Global: [
             "{LUSTREDIR}/project/metproduction/products/icon/"


### PR DESCRIPTION
There was an extra } in the input dir path when using EC global meteorology. This made running global simulation with EC meteorology crash. 