### PR TITLE
Grib bitmap

### DIFF
--- a/utils/SnapPy/Snappy/resources/fillValue_template.ncml
+++ b/utils/SnapPy/Snappy/resources/fillValue_template.ncml
@@ -1,0 +1,4 @@
+<!-- change the isotopes fill-value to be able to set 0 as bit-map in grib1-packing -->
+<variable name="{varname}" type="float">
+   <attribute name="_FillValue" type="float" value="0."/>
+</variable>

--- a/utils/SnapPy/Snappy/resources/removeSnapReferenceTime.ncml
+++ b/utils/SnapPy/Snappy/resources/removeSnapReferenceTime.ncml
@@ -5,4 +5,6 @@
 
 <remove type="attribute" name="SIMULATION_START_DATE" />
 
+{variables}
+
 </netcdf>

--- a/utils/SnapPy/nc2grib.py
+++ b/utils/SnapPy/nc2grib.py
@@ -3,56 +3,11 @@
 import os
 import subprocess
 import sys
-from Snappy.Resources import Resources
-
-def convert_to_grib(snapNc, basedir, ident, isotopes):
-    config = Resources().getGribWriterConfig(isotopes)
-    xmlFile = "cdmGribWriterConfig.xml"
-    basexmlFile = os.path.join(basedir, xmlFile)
-    with open(basexmlFile, 'w') as xh:
-        xh.write(config['xml'])
-    errlog = open(os.path.join(basedir, "fimex.errlog"), "w")
-    outlog = open(os.path.join(basedir, "fimex.outlog"), "w")
-    tempfile = 'tmp.grib'
-    basetempfile = os.path.join(basedir, tempfile)
-    # fimex works in basedir, so it does not need the basefiles
-    for appendix, params in config['extracts'].items():
-        outFile = os.path.join(basedir, "{ident}_{type}".format(ident=ident, type=appendix))
-        with open(outFile, 'wb') as gh:
-            for param in params:
-                if (os.path.exists(basetempfile)):
-                    os.remove(basetempfile)
-                procOptions = ['fimex', '--input.file={}'.format(snapNc), '--input.config={}'.format(config['ncml']),
-                       # avoid problem with lat/lon variables
-                       # in fimex grib-writer< 0.64
-                       # '--extract.removeVariable=longitude',
-                       # '--extract.removeVariable=latitude',
-                       '--output.file={}'.format(tempfile),
-                       '--output.type=grib', '--output.config={}'.format(xmlFile)]
-                procOptions.append('--extract.selectVariables={}'.format(param))
-                print(" ".join(procOptions))
-                proc = subprocess.Popen(procOptions, cwd=basedir, stderr=errlog, stdout=outlog)
-                if (proc.wait() != 0):
-                    errlog.write("'{fimex}' in {dir} failed".format(fimex=' '.join(procOptions), dir=basedir))
-                else:
-                    # append tmp-file to final grib-file
-                    with (open(basetempfile, 'rb')) as th:
-                        while True:
-                            data = th.read(16*1024*1024) # read max 16M blocks
-                            if data:
-                                gh.write(data)
-                            else:
-                                break
-                if (os.path.exists(basetempfile)):
-                    os.remove(basetempfile)
-
-    errlog.close()
-    outlog.close()
-
+from Snappy.Resources import Resources, snapNc_convert_to_grib
 
 if __name__ == "__main__":
     ncfile = sys.argv[1]
     ident = sys.argv[2]
-    isotopes = [int(sys.argv[3])]
+    isotopes = [int(x) for x in sys.argv[3:]]
     dirname = os.path.dirname(ncfile)
-    convert_to_grib(ncfile, dirname, ident, isotopes)
+    snapNc_convert_to_grib(ncfile, dirname, ident, isotopes)

--- a/utils/SnapPy/snap4rimsterm
+++ b/utils/SnapPy/snap4rimsterm
@@ -26,7 +26,7 @@ import sys
 
 from Snappy.EcMeteorologyCalculator import EcMeteorologyCalculator
 from Snappy.ICONMeteorologyCalculator import ICONMeteorologyCalculator
-from Snappy.Resources import MetModel, Resources
+from Snappy.Resources import MetModel, Resources, snapNc_convert_to_grib
 import xml.etree.ElementTree as ET
 
 
@@ -182,51 +182,6 @@ STEP.HOUR.OUTPUT.FIELDS= {outputTimestep:d}
 
     return sourceTerm
 
-def convert_to_grib(snapNc, basedir, ident, isotopes):
-    config = Resources().getGribWriterConfig(isotopes)
-    xmlFile = "cdmGribWriterConfig.xml"
-    basexmlFile = os.path.join(basedir, xmlFile)
-    with open(basexmlFile, 'w') as xh:
-        xh.write(config['xml'])
-    errlog = open(os.path.join(basedir, "fimex.errlog"), "w")
-    outlog = open(os.path.join(basedir, "fimex.outlog"), "w")
-    tempfile = 'tmp.grib'
-    basetempfile = os.path.join(basedir, tempfile)
-    # fimex works in basedir, so it does not need the basefiles
-    for appendix, params in config['extracts'].items():
-        outFile = os.path.join(basedir, "{ident}_{type}".format(ident=ident, type=appendix))
-        with open(outFile, 'wb') as gh:
-            for param in params:
-                if (os.path.exists(basetempfile)):
-                    os.remove(basetempfile)
-                procOptions = ['fimex', '--input.file=snap.nc', '--input.config={}'.format(config['ncml']),
-                       # avoid problem with lat/lon variables
-                       # in fimex grib-writer< 0.64
-                       # '--extract.removeVariable=longitude',
-                       # '--extract.removeVariable=latitude',
-                       '--output.file={}'.format(tempfile),
-                       '--output.type=grib', '--output.config={}'.format(xmlFile)]
-                procOptions.append('--extract.selectVariables={}'.format(param))
-                print(" ".join(procOptions))
-                proc = subprocess.Popen(procOptions, cwd=basedir, stderr=errlog, stdout=outlog)
-                if (proc.wait() != 0):
-                    errlog.write("'{fimex}' in {dir} failed".format(fimex=' '.join(procOptions), dir=basedir))
-                else:
-                    # append tmp-file to final grib-file
-                    with (open(basetempfile, 'rb')) as th:
-                        while True:
-                            data = th.read(16*1024*1024) # read max 16M blocks
-                            if data:
-                                gh.write(data)
-                            else:
-                                break
-                if (os.path.exists(basetempfile)):
-                    os.remove(basetempfile)
-
-    errlog.close()
-    outlog.close()
-
-
 def snap4rimsterm(rimsterm, argosrequest, basedir, ident, met_model):
     '''run snap with rimsterm definition in basedir dir'''
     tree = ET.parse(rimsterm)
@@ -270,14 +225,14 @@ def snap4rimsterm(rimsterm, argosrequest, basedir, ident, met_model):
         for oformat in argosRoot.findall("OutputFormat"):
             print("output in format: {}".format(oformat.text))
             if oformat.text == 'GRIB':
-                convert_to_grib(snapNC, basedir, ident, rimstermGetIsotopes(root).values())
+                snapNc_convert_to_grib(snapNC, basedir, ident, rimstermGetIsotopes(root).values())
             elif oformat.text == 'NetCDF':
                 # create a filename which can be picked up by SMS
                 os.symlink(snapNC, os.path.join(basedir,"{}_all.nc".format(ident)))
             else:
                 raise Exception("unknown OutputFormat in request: {}".format(oformat.text))
     else:
-        convert_to_grib(snapNC, basedir, ident, rimstermGetIsotopes(root).values())
+        snapNc_convert_to_grib(snapNC, basedir, ident, rimstermGetIsotopes(root).values())
 
 
 


### PR DESCRIPTION
Use 0 as fill-value before converting to grib. fimex-grib-translation will use the fill-value as bitmap mask and only write data not corresponding to that bitmap. Data-reduction for a typical 68h run, 7 components: 4x 388MB -> 4x 15MB (> factor 20).

Currently, bitmap packing is the only grib-compression algorithm supported by argos.
