### PR TITLE
Ec global direct

### DIFF
--- a/utils/SnapPy/Snappy/EcMeteorologyCalculator.py
+++ b/utils/SnapPy/Snappy/EcMeteorologyCalculator.py
@@ -66,7 +66,7 @@ class EcMeteorologyCalculator(Snappy.MeteorologyCalculator.MeteorologyCalculator
         res.indirs = ecres.getMetGlobalInputDirs(MetModel.NrpaEC0p1Global)
         res.pathglob = "ec_atmo_0_1deg_????????T??????Z_3h.nc"
         res.pathptime = "ec_atmo_0_1deg_%Y%m%dT%H%M%SZ_3h.nc"
-        res.path_grace_period_sec = 15*60 # files continuously written, wait for completion
+        res.path_grace_period_sec = 2*60 # 2min grace to ensure lustre cross-dir mv finishes
         res.outputdir = ecres.getSnapOutputDir()
         res.output_filename_pattern = ecres.EC_FILENAME_PATTERN
         res.domainHeight = ecres.ecDomainHeight

--- a/utils/SnapPy/Snappy/EcMeteorologyCalculator.py
+++ b/utils/SnapPy/Snappy/EcMeteorologyCalculator.py
@@ -58,6 +58,7 @@ class EcMeteorologyCalculator(Snappy.MeteorologyCalculator.MeteorologyCalculator
         '''
         return Snappy.MeteorologyCalculator.MeteorologyCalculator.findGlobalData(EcMeteorologyCalculator.getGlobalMeteoResources(), dtime)
 
+
     @staticmethod
     def getGlobalMeteoResources():
         '''retrieve the GlobalMeteoResources from internal resources'''

--- a/utils/SnapPy/Snappy/MeteorologyCalculator.py
+++ b/utils/SnapPy/Snappy/MeteorologyCalculator.py
@@ -107,6 +107,18 @@ class MeteorologyCalculator(abc.ABC):
         pass
 
 
+    def getLat0(latCenter, domainHeight):
+        # get a domain starting every 10th degree
+        lat0 = math.floor((latCenter-(domainHeight/2.))/10.)*10
+        if (lat0 < -80): lat0 = -89
+        if (lat0+domainHeight > 89): lat0 = 89 - domainHeight
+        return lat0
+    def getLon0(lonCenter, domainWidth):
+        # get a domain starting every 10th degree
+        lon0 = math.floor((lonCenter-(domainWidth/2.))/10.)*10
+        return lon0
+
+
     def __init__(self, res: GlobalMeteoResource, dtime: datetime, domainCenterX, domainCenterY):
         '''Calculate the ec-meteorology unless it exists
 

--- a/utils/SnapPy/Snappy/MeteorologyCalculator.py
+++ b/utils/SnapPy/Snappy/MeteorologyCalculator.py
@@ -70,11 +70,10 @@ class MeteorologyCalculator(abc.ABC):
     '''Base-class to pre-calculate/extract meteorology'''
     @staticmethod
     def findAllGlobalData(res: GlobalMeteoResource): 
-        '''Static method to find the all global dataset
+        '''Static method to find all global dataset.
 
         Args:
             dtime: datetime object with a start-time, which should be included in the dataset
-            count: number of file
 
         Returns:
             A list of tuples with [(forecast-time, file)]
@@ -90,11 +89,11 @@ class MeteorologyCalculator(abc.ABC):
 
     @staticmethod
     def findGlobalData(res: GlobalMeteoResource, dtime: datetime):
-        '''Method to find the closest global dataset earlier than dtime.
+        '''Method to find the global dataset with the latest forecast time which includes dtime.
 
         Args:
             res: resources from getGlobalMeteoResources
-            dtime: datetime object with a start-time, which should be included in the dataset
+            dtime: datetime object with a start-time, which will be included in the dataset
 
         Returns:
             A tuple with referencetime and filename

--- a/utils/SnapPy/Snappy/Resources.py
+++ b/utils/SnapPy/Snappy/Resources.py
@@ -42,6 +42,7 @@ class MetModel(enum.Enum):
     Meps2p5 = "meps_2_5km"
     NrpaEC0p1 = "nrpa_ec_0p1"
     NrpaEC0p1Global = "nrpa_ec_0p1_global"
+    EC0p1Global = "ec_0p1_global"
     GfsGribFilter = "gfs_grib_filter_fimex"
 
     def __eq__(self, other):
@@ -67,6 +68,9 @@ class Resources(ResourcesCommon):
 
     _MET_GLOBAL_INPUTDIRS = {
         MetModel.NrpaEC0p1Global: [
+            "{LUSTREDIR}/project/metproduction/products/ecmwf/nc/"
+        ],
+        MetModel.EC0p1Global: [
             "{LUSTREDIR}/project/metproduction/products/ecmwf/nc/"
         ],
         MetModel.Icon0p25Global: ["{LUSTREDIR}/project/metproduction/products/icon/"],
@@ -133,6 +137,8 @@ class Resources(ResourcesCommon):
                 "dx": self.ecDomainRes,
                 "dy": self.ecDomainRes,
             }
+        elif metmodel == MetModel.EC0p1Global:
+            return {}
         elif metmodel == MetModel.Meps2p5:
             return {}
         elif metmodel == MetModel.Icon0p25Global:
@@ -380,6 +386,8 @@ GRAVITY.FIXED.M/S=0.0002
         """
         if (metmodel == MetModel.NrpaEC0p1) or (metmodel == MetModel.NrpaEC0p1Global):
             filename = os.path.join(self.directory, "snap.input_nrpa_ec_0p1.tmpl")
+        elif metmodel == MetModel.EC0p1Global:
+            filename = os.path.join(self.directory, "snap.input_ec_0p1.tmpl")
         elif metmodel == MetModel.Meps2p5:
             filename = os.path.join(self.directory, "snap.input_meps_2_5km.tmpl")
         elif metmodel == MetModel.Icon0p25Global:
@@ -405,6 +413,9 @@ GRAVITY.FIXED.M/S=0.0002
             # no setup needed, autdetection in snap
             pass
         elif metmodel == MetModel.NrpaEC0p1Global:
+            # no setup needed, autdetection in snap
+            pass
+        elif metmodel == MetModel.EC0p1Global:
             # no setup needed, autdetection in snap
             pass
         elif metmodel == MetModel.Meps2p5:

--- a/utils/SnapPy/Snappy/SnapController.py
+++ b/utils/SnapPy/Snappy/SnapController.py
@@ -35,7 +35,7 @@ from PyQt5.QtCore import (
 from Snappy.BrowserWidget import BrowserWidget
 from Snappy.EcMeteorologyCalculator import EcMeteorologyCalculator
 from Snappy.ICONMeteorologyCalculator import ICONMeteorologyCalculator
-from Snappy.MeteorologyCalculator import MeteoDataNotAvailableException
+from Snappy.MeteorologyCalculator import MeteoDataNotAvailableException, MeteorologyCalculator
 from Snappy.MailImages import sendPngsFromDir
 from Snappy.Resources import Resources, MetModel
 import Snappy.Utils
@@ -597,7 +597,7 @@ STEP.HOUR.OUTPUT.FIELDS= 3
         with open(os.path.join(self.lastOutputDir, "snap.input"), "w") as fh:
             fh.write(self.lastSourceTerm)
 
-        if qDict["metmodel"] == "nrpa_ec_0p1":
+        if qDict["metmodel"] == MetModel.NrpaEC0p1:
             files = self.res.getECMeteorologyFiles(
                 startDT, int(qDict["runTime"]), qDict["ecmodelrun"]
             )
@@ -625,6 +625,17 @@ STEP.HOUR.OUTPUT.FIELDS= 3
                 self._met_calculate_and_run()
             except MeteoDataNotAvailableException as e:
                 self.write_log("problems creating EC-met: {}".format(e.args[0]))
+        elif qDict["metmodel"] == MetModel.EC0p1Global:
+            try:
+                files = EcMeteorologyCalculator.findECGlobalData(startDT)
+                globalRes = EcMeteorologyCalculator.getGlobalMeteoResources()
+                lat0 = MeteorologyCalculator.getLat0(latf, globalRes.domainHeight)
+                lon0 = MeteorologyCalculator.getLat0(lonf, globalRes.domainWidth)
+                with open(os.path.join(self.lastOutputDir, "snap.input"), "a") as fh:
+                    fh.write(f'FIMEX.INTERPOLATION=nearest|+proj=latlon +R=6371000 +no_defs|{lon0},{lon0+0.2},...,{lon0+globalRes.domainWidth}|{lat0},{lat0+0.2},...,{lat0+globalRes.domainHeight}|degree')
+                    fh.write(self.res.getSnapInputMetDefinitions(qDict["metmodel"], files))
+            except MeteoDataNotAvailableException as e:
+                self.write_log("problems finding global EC-met: {}".format(e.args[0]))
         elif qDict["metmodel"] == MetModel.Icon0p25Global:
             try:
                 self.write_log("extracting meteorology from ICON for domain")

--- a/utils/SnapPy/Snappy/SnapController.py
+++ b/utils/SnapPy/Snappy/SnapController.py
@@ -627,13 +627,16 @@ STEP.HOUR.OUTPUT.FIELDS= 3
                 self.write_log("problems creating EC-met: {}".format(e.args[0]))
         elif qDict["metmodel"] == MetModel.EC0p1Global:
             try:
-                files = EcMeteorologyCalculator.findECGlobalData(startDT)
                 globalRes = EcMeteorologyCalculator.getGlobalMeteoResources()
+                files = [x[1] for x in sorted(MeteorologyCalculator.findAllGlobalData(globalRes), key=lambda x: x[0])]
                 lat0 = MeteorologyCalculator.getLat0(latf, globalRes.domainHeight)
                 lon0 = MeteorologyCalculator.getLat0(lonf, globalRes.domainWidth)
                 with open(os.path.join(self.lastOutputDir, "snap.input"), "a") as fh:
-                    fh.write(f'FIMEX.INTERPOLATION=nearest|+proj=latlon +R=6371000 +no_defs|{lon0},{lon0+0.2},...,{lon0+globalRes.domainWidth}|{lat0},{lat0+0.2},...,{lat0+globalRes.domainHeight}|degree')
+                    fh.write(f"FIELD.TYPE=fimex\n")
+                    fh.write(f"FIMEX.FILE_TYPE=netcdf\n")
+                    fh.write(f"FIMEX.INTERPOLATION=nearest|+proj=latlon +R=6371000 +no_defs|{lon0},{lon0+0.2},...,{lon0+globalRes.domainWidth}|{lat0},{lat0+0.2},...,{lat0+globalRes.domainHeight}|degree\n")
                     fh.write(self.res.getSnapInputMetDefinitions(qDict["metmodel"], files))
+                self._snap_model_run()
             except MeteoDataNotAvailableException as e:
                 self.write_log("problems finding global EC-met: {}".format(e.args[0]))
         elif qDict["metmodel"] == MetModel.Icon0p25Global:

--- a/utils/SnapPy/Snappy/resources/snap.input_ec_0p1.tmpl
+++ b/utils/SnapPy/Snappy/resources/snap.input_ec_0p1.tmpl
@@ -1,0 +1,55 @@
+***********************************************************************
+*** MET Norway SNAP input file
+***********************************************************************
+RANDOM.WALK.ON
+BOUNDARY.LAYER.FULL.MIX.OFF
+DRY.DEPOSITION.NEW
+WET.DEPOSITION.VERSION = 2
+
+REMOVE.RELATIVE.MASS.LIMIT= 0.
+
+MAX.TOTALPARTICLES= 20000000
+MAX.PARTICLES.PER.RELEASE= 2000
+TIME.STEP= 600.
+STEP.HOUR.INPUT.MIN= 3 
+STEP.HOUR.INPUT.MAX= 6
+STEP.HOUR.OUTPUT.FIELDS= 3
+ASYNOPTIC.OUTPUT
+TOTAL.COMPONENTS.OFF
+MSLP.OFF
+PRECIPITATION.ON
+MODEL.LEVEL.FIELDS.OFF
+POSITIONS.DECIMAL
+
+** INPUT FIELD FILES
+*
+FIELD.TYPE=fimex
+FIMEX.FILE_TYPE= netcdf
+FIMEX.INTERPOLATION=nearest|+proj=latlon +R=6371000 +no_defs|-50,-49.8,...,70|25,25.2,...,85|degree
+
+GRID.AUTODETECT.FROM_INPUT
+GRID.NCTYPE = ec_det
+DATA.ETA.LEVELS
+ENSEMBLE_MEMBER.INPUT = 0
+* use all layers (autodetect removes lowest)
+LEVELS.INPUT= 49,0,48,47,46,45,44,43,42,41,40,39,38,37,36,35,34,33,32,31,30,29,28,27,26,25,24,23,22,21,20,19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1
+
+
+FIELD_TIME.FORECAST
+
+** OUTPUT FILES
+FIELD.OUTTYPE=netcdf
+FIELD.OUTPUT= snap.nc
+
+* OUTPUT.AIRCRAFT_DOSERATE.ENABLE
+* Tiltaksgrense Avsperring
+* Se Sivilforsvaret Bestemmelser om sikkerhet under opplæring, øving og
+* innsats i Sivilforsvaret
+* Grense i Sv/h
+OUTPUT.AIRCRAFT_DOSERATE.THRESHOLD.SV_H = 60e-6
+
+
+LOG.FILE=     snap.log
+DEBUG.ON
+
+

--- a/utils/SnapPy/Snappy/resources/snap.input_ec_0p1.tmpl
+++ b/utils/SnapPy/Snappy/resources/snap.input_ec_0p1.tmpl
@@ -21,14 +21,9 @@ PRECIPITATION.ON
 MODEL.LEVEL.FIELDS.OFF
 POSITIONS.DECIMAL
 
-** INPUT FIELD FILES
-*
-FIELD.TYPE=fimex
-FIMEX.FILE_TYPE= netcdf
-FIMEX.INTERPOLATION=nearest|+proj=latlon +R=6371000 +no_defs|-50,-49.8,...,70|25,25.2,...,85|degree
-
 GRID.AUTODETECT.FROM_INPUT
-GRID.NCTYPE = ec_det
+* ec_det in newer versions of snap
+GRID.NCTYPE = ec_n1s
 DATA.ETA.LEVELS
 ENSEMBLE_MEMBER.INPUT = 0
 * use all layers (autodetect removes lowest)

--- a/utils/SnapPy/Snappy/resources/startScreen.html
+++ b/utils/SnapPy/Snappy/resources/startScreen.html
@@ -126,6 +126,7 @@ function togglebomb(element)
              <option selected="selected" value="nrpa_ec_0p1">EC 0.1, NRPA-domain</option>
              <option value="meps_2_5km">MEPS-det 2.5km</option>
              <option value="nrpa_ec_0p1_global">EC 0.1, global, slow</option>
+             <option value="ec_0p1_global">EC 0.2, global, long forecast</option>
              <option value="icon_0p25_global">DWD/Nato ICON 0.25, global</option>
          </select>
          <br/>EC-Model Runtime

--- a/utils/SnapPy/debian.bionic/control
+++ b/utils/SnapPy/debian.bionic/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.7
 
 Package: snap-py
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends}, bsnap (>= 2.0.0), python3-pyqt5, python3-pyqt5.qtwebkit
+Depends: ${misc:Depends}, ${python3:Depends}, bsnap (>= 2.1.2), python3-pyqt5, python3-pyqt5.qtwebkit
 Description: SNAP GUI in python
 
 

--- a/utils/SnapPy/snap4rimsterm
+++ b/utils/SnapPy/snap4rimsterm
@@ -26,6 +26,7 @@ import sys
 
 from Snappy.EcMeteorologyCalculator import EcMeteorologyCalculator
 from Snappy.ICONMeteorologyCalculator import ICONMeteorologyCalculator
+from Snappy.MeteorologyCalculator import MeteorologyCalculator
 from Snappy.Resources import MetModel, Resources, snapNc_convert_to_grib
 import xml.etree.ElementTree as ET
 
@@ -160,6 +161,14 @@ STEP.HOUR.OUTPUT.FIELDS= {outputTimestep:d}
             raise Exception("no EC met-files calculated for {}".format(startDTime))
         files = ecmet.get_meteorology_files()
         (metdef["startX"], metdef["startY"]) = ecmet.get_grid_startX_Y()
+    elif met_model == MetModel.EC0p1Global:
+        globalRes = EcMeteorologyCalculator.getGlobalMeteoResources()
+        files = [x[1] for x in sorted(MeteorologyCalculator.findAllGlobalData(globalRes), key=lambda x: x[0])]
+        lat0 = MeteorologyCalculator.getLat0(float(lat), globalRes.domainHeight)
+        lon0 = MeteorologyCalculator.getLat0(float(lon), globalRes.domainWidth)
+        sourceTerm += f"FIELD.TYPE=fimex\n"
+        sourceTerm += f"FIMEX.FILE_TYPE=netcdf\n"
+        sourceTerm += f"FIMEX.INTERPOLATION=nearest|+proj=latlon +R=6371000 +no_defs|{lon0},{lon0+0.2},...,{lon0+globalRes.domainWidth}|{lat0},{lat0+0.2},...,{lat0+globalRes.domainHeight}|degree\n"
     elif met_model == MetModel.Meps2p5:
         files = res.getMeteorologyFiles(met_model, startDTime, runTime, "best")
         if (len(files) == 0):
@@ -242,7 +251,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="run snap from a rimsterm.xml file and convert to grib-files named ident_conc, ident_depo ident_wetd ident_dose ident_tofa")
     parser.add_argument("--rimsterm", help="source-term in rimsterm format", required=False)
     parser.add_argument("--argosrequest", help="optional argos-request xml file in addition to --rimsterm file", required=False)
-    parser.add_argument("--metmodel", help="select the NWP input model, nrpa_ec_0p1, nrpa_ec_0p1_global, meps_2_5km, gfs_grib_filter_fimex, icon_0p25_global", required=True, default='nrpa_ec_0p1')
+    parser.add_argument("--metmodel", help="select the NWP input model, nrpa_ec_0p1, nrpa_ec_0p1_global, meps_2_5km, ec_0p1_global, gfs_grib_filter_fimex, icon_0p25_global", required=True, default='nrpa_ec_0p1')
     parser.add_argument("--dir", help="output-directory", required=True)
     parser.add_argument("--ident", help="output-file identifier", required=True)
     parser.add_argument("--bitmapCompress", help="enable grib bitmap-compression", action='store_true')

--- a/utils/SnapPy/snapRunnerNpp
+++ b/utils/SnapPy/snapRunnerNpp
@@ -299,11 +299,20 @@ def runsnap(npp, met_model, outdir, release_dt, runtime, plot_from_file=None):
     ax.set_extent([x[50],x[-50],y[25],y[-1]], crs=proj)
     clevs=range(0,(steps+1)*stepH,2*stepH)
     colors = [ plt.cm.jet(x) for x in numpy.linspace(0.95,0.1,len(clevs)) ]
-    # dsa colors up to 48 hours
-    colors[0] = rgbToColor('128:0:255')
-    colors[1] = rgbToColor('128:128:255')
-    colors[2] = rgbToColor('128:128:192')
-    colors[3] = rgbToColor('192:192:192')
+    # dsa colors up to 48 hours, here only every 6 hours
+    # 255:0:255,255:128:255  0-3;3-6
+    # 128:0:128,128:0:255    6-9,9-12
+    # 128:128:255 12-24 (split in two)
+    # 128:128:192 24-36 (split in two)
+    # 192:192:192 36-48 (split in two)
+    colors[0] = rgbToColor('255:128:255')
+    colors[1] = rgbToColor('128:0:255')
+    colors[2] = rgbToColor('128:64:255')
+    colors[3] = rgbToColor('128:128:255')
+    colors[4] = rgbToColor('128:128:225')
+    colors[5] = rgbToColor('128:128:192')
+    colors[6] = rgbToColor('160:160:192')
+    colors[7] = rgbToColor('192:192:192')
     cs = plotMap(toa[:],
             title="Time of arrival",
             title_loc="left",

--- a/utils/SnapPy/snapRunnerNpp
+++ b/utils/SnapPy/snapRunnerNpp
@@ -4,6 +4,7 @@ import argparse
 import datetime
 import cartopy
 import matplotlib
+
 matplotlib.use('Agg')
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 from matplotlib import pyplot as plt
@@ -17,6 +18,7 @@ from time import gmtime, strftime, strptime
 
 from Snappy.EcMeteorologyCalculator import EcMeteorologyCalculator
 from Snappy.ICONMeteorologyCalculator import ICONMeteorologyCalculator
+from Snappy.MeteorologyCalculator import MeteorologyCalculator
 from Snappy.Resources import MetModel, Resources
 from Snappy.Countries import get_country_list
 
@@ -182,6 +184,14 @@ def runsnap(npp, met_model, outdir, release_dt, runtime, plot_from_file=None):
                     raise Exception("no EC met-files calculated for {}".format(release_dt))
                 files = ecmet.get_meteorology_files()
                 (metdef["startX"], metdef["startY"]) = ecmet.get_grid_startX_Y()
+            elif met_model == MetModel.EC0p1Global:
+                globalRes = EcMeteorologyCalculator.getGlobalMeteoResources()
+                files = [x[1] for x in sorted(MeteorologyCalculator.findAllGlobalData(globalRes), key=lambda x: x[0])]
+                lat0 = MeteorologyCalculator.getLat0(float(lat), globalRes.domainHeight)
+                lon0 = MeteorologyCalculator.getLat0(float(lon), globalRes.domainWidth)
+                fh.write(f"FIELD.TYPE=fimex\n")
+                fh.write(f"FIMEX.FILE_TYPE=netcdf\n")
+                fh.write(f"FIMEX.INTERPOLATION=nearest|+proj=latlon +R=6371000 +no_defs|{lon0},{lon0+0.2},...,{lon0+globalRes.domainWidth}|{lat0},{lat0+0.2},...,{lat0+globalRes.domainHeight}|degree\n")
             elif met_model == MetModel.Meps2p5:
                 files = res.getMeteorologyFiles(met_model, release_dt, runtime, "best")
                 if (len(files) == 0):
@@ -330,7 +340,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--outdir", help="output directory for file ", default='.')
     parser.add_argument("--store", help="storeA or storeB, meteo and runtime-datastore, default used from MAPP-system")
-    parser.add_argument("--metmodel", help="the metmodel to use: nrpa_ec_0p1, nrpa_ec_0p1_global, meps_2_5km, gfs_grib_filter_fimex, icon_0p25_global", default='nrpa_ec_0p1')
+    parser.add_argument("--metmodel", help="the metmodel to use: nrpa_ec_0p1, nrpa_ec_0p1_global, ec_0p1_global, meps_2_5km, gfs_grib_filter_fimex, icon_0p25_global", default='nrpa_ec_0p1')
     parser.add_argument("--starttime", help="start time YYYY-MM-DD_HH")
     parser.add_argument("--runtime", help="the run and releasetime", required=True)
     parser.add_argument("--plotonly_ncfile", help="don't run the model plot only from this ncfile")


### PR DESCRIPTION
Enabling to SnapPy, snapRunnerNpp and snap4rimsterm to read directly from the ec_atoms_*_3h.nc files rather than converting first to emep-input files. This makes it possible to run up to 10 day forecasts.