### PR TITLE
set the minimul Bq per model-particle to a very low number

### DIFF
--- a/src/common/particleML.f90
+++ b/src/common/particleML.f90
@@ -17,12 +17,12 @@
 
 module particleML
     USE iso_fortran_env, only: real64, int16
-    USE ieee_arithmetic, only: IEEE_POSITIVE_DENORMAL, IEEE_CLASS_TYPE
     implicit none
     private
 
     !> numerical limit for particle-rad contents so that common computations
-    !> like decay or deposition don't become subnormal (float-subnormal: 1e-38)
+    !> like decay or deposition don't become subnormal
+    !> (smallest possible normal float: ~1e-38)
     real, public, parameter :: numeric_limit_rad = 1000. * 1e-38
 
 !> a simple particle to be stored

--- a/src/common/particleML.f90
+++ b/src/common/particleML.f90
@@ -17,8 +17,13 @@
 
 module particleML
     USE iso_fortran_env, only: real64, int16
+    USE ieee_arithmetic, only: IEEE_POSITIVE_DENORMAL, IEEE_CLASS_TYPE
     implicit none
     private
+
+    !> numerical limit for particle-rad contents so that common computations
+    !> like decay or deposition don't become subnormal (float-subnormal: 1e-38)
+    real, public, parameter :: numeric_limit_rad = 1000. * 1e-38
 
 !> a simple particle to be stored
     type, public :: particle

--- a/src/common/rmpart.f90
+++ b/src/common/rmpart.f90
@@ -28,7 +28,7 @@ module rmpartML
 !> remaining mass is transferred to to the other particles
 !> in the same plume (or to the next plume if none left).
 subroutine rmpart(rmlimit)
-  USE particleML, only: pdata
+  USE particleML, only: pdata, numeric_limit_rad
   USE snapparML, only: ncomp, run_comp, iparnum, def_comp
   USE releaseML, only: iplume, plume_release, nplume, npart
 
@@ -76,7 +76,8 @@ subroutine rmpart(rmlimit)
       do i=i1,i2
         m=pdata(i)%icomp
         mm = def_comp(m)%to_running
-        if(pdata(i)%rad > (plume_release(npl, mm)*rmlimit)) then
+        if((pdata(i)%rad > numeric_limit_rad) .and. &
+           (pdata(i)%rad > (plume_release(npl, mm)*rmlimit))) then
           pbqtotal(mm)=pbqtotal(mm)+pdata(i)%rad
           npkeep(mm) = npkeep(mm) + 1
         else


### PR DESCRIPTION
Avoid numerical subnormals not being removed from the model by setting a slightly higher limit of Bq/model-particle to 1000.*1e-38(=positive_subnormal).