### PR TITLE
Status codes

### DIFF
--- a/utils/SnapPy/README.md
+++ b/utils/SnapPy/README.md
@@ -10,7 +10,8 @@ with status_number/text combinations like:
 |code| message|type|
 |--- | --- | --- |
 |100 | Getting ARGOS data from server | Processing |
-|101 | running {model} | Processing |
+|101 | queued {model} for processing | Processing  (queued) |
+|102 | Starting run for {model} (timeout: 2h) | Processing (running) |
 |202 | Finished extracting {model} data for ARGOS | Success |
 |409 | {model} output data do not exist | Error, customers responsibility |
 |409 | {model} output data does not exist, snap4rimsterm failed |  Error, customers responsibility |

--- a/utils/SnapPy/README.md
+++ b/utils/SnapPy/README.md
@@ -7,14 +7,14 @@ Files are stored on production machine and then copied to the remote machine.
   ```status_number:timestamp:text```
 
 with status_number/text combinations like:
-|code| message|type|
-|--- | --- | --- |
+|code| message|type|note|
+|--- | --- | --- | --- |
 |100 | Getting ARGOS data from server | Processing |
-|101 | queued {model} for processing | Processing  (queued) |
-|102 | Starting run for {model} (timeout: 2h) | Processing (running) |
-|202 | Finished extracting {model} data for ARGOS | Success |
-|409 | {model} output data do not exist | Error, customers responsibility |
-|409 | {model} output data does not exist, snap4rimsterm failed |  Error, customers responsibility |
+|101 | queued {model} for processing | Processing  | queued |
+|102 | Starting run for {model} (timeout: 2h) | Processing | running |
+|202 | Finished extracting {model} data for ARGOS | Success | only code ARGOS reacts upon, all others are send to user |
+|409 | {model} output data do not exist | Input Error | customer responsibility |
+|409 | {model} output data does not exist, snap4rimsterm failed |  Input Error | customers responsibility |
 |410 | {model} internal error copying data to destination | Internal Error |
 |410 | {model} internal error, zip failed | Internal Error |
 |410 | {model} internal error, ncatted failed | Internal Error |

--- a/utils/SnapPy/Snappy/SnapJobEC.py
+++ b/utils/SnapPy/Snappy/SnapJobEC.py
@@ -118,7 +118,7 @@ ulimit -c 0
 export OMP_NUM_THREADS=1
 
 cd {rundir}
-send_msg 101 "Starting run for {model} (timeout: 2h)"
+send_msg 102 "Starting run for {model} (timeout: 2h)"
 snap4rimsterm --rimsterm {xmlfile} {argosrequest} --dir . --ident {ident}_SNAP --metmodel {metmodel} --bitmapCompress
 if [ $? -ne 0 ]; then
     send_msg 409 "{model} output data does not exist, snap4rimsterm failed"

--- a/utils/SnapPy/snapRemoteRunner.py
+++ b/utils/SnapPy/snapRemoteRunner.py
@@ -319,7 +319,7 @@ class SnapRemoteRunner:
                 )
             elif tag == "running":
                 fh.write(
-                    "101:{ts}::running {model}\n".format(ts=timestamp, model=task.model)
+                    "101:{ts}::queued {model} for processing\n".format(ts=timestamp, model=task.model)
                 )
             elif tag == "internal":
                 fh.write(


### PR DESCRIPTION
Needing a new status code to differ between `send to queue` and `running in queue` for monitoring. First code should not remain without being handled for 10min, second should be handled within 2h. Should not affect ARGOS, but since it is a change to the user, it is a moderate rather than minor change.