### PR TITLE
Conservative horizontal diffusion

### DIFF
--- a/src/common/rwalk.f90
+++ b/src/common/rwalk.f90
@@ -30,7 +30,7 @@ module rwalkML
 
   real(real64), parameter :: hmax = 2500.0 ! maximum mixing height
   real(real64), parameter :: tmix_v = 15.0*60.0 ! Characteristic mixing time = 15 min (to reach full bl-height)
-  real(real64), parameter :: tmix_h = 60.0*60.0 ! Horizontal base-time time = 60 min (to reach ax^b width)
+  real(real64), parameter :: tmix_h = 15.0*60.0 ! Horizontal base-time time = 15 min (to reach ax^b width)
   real(real64), parameter :: lmax = 0.28 ! Maximum l-eta in the mixing layer
   real(real64), parameter :: labove = 0.03 ! Standard l-eta above the mixing layer
   real(real64), parameter :: entrainment = 0.1 ! Entrainment zone = 10%*h

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -13,8 +13,8 @@ include ../common/snap.mk
 TESTFILES = snap_testdata/meteo20200415_00_ringhals.nc \
 			snap_testdata/meteo20200415_01_ringhals.nc \
             snap_testdata/meps_det_2_5km_20200316T00Z_ringhals.nc \
-			snap_testdata/snap_ecemep_expected2.nc \
-			snap_testdata/snap_meps_interpolated_expected2.nc
+			snap_testdata/snap_ecemep_expected3.nc \
+			snap_testdata/snap_meps_interpolated_expected3.nc
 
 install:
 

--- a/src/test/snap_forward_test.py
+++ b/src/test/snap_forward_test.py
@@ -16,7 +16,7 @@ class SnapEcEMEPForwardTestCase(SnapTestCase):
     snap = "../bsnap_naccident"
     datadir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
 
-    snapExpected = "snap_testdata/snap_ecemep_expected2.nc"
+    snapExpected = "snap_testdata/snap_ecemep_expected3.nc"
 
     def setUp(self):
         pass
@@ -87,7 +87,7 @@ class SnapMEPSForwardTestCase(SnapTestCase):
     snap = "../bsnap_naccident"
     datadir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
 
-    snapExpected = "snap_testdata/snap_meps_interpolated_expected2.nc"
+    snapExpected = "snap_testdata/snap_meps_interpolated_expected3.nc"
 
     def setUp(self):
         pass


### PR DESCRIPTION
Reducing the horizontal diffusion base-time form 60min to 15min. This was never documented anywhere (only for vertical diffusion) and was recently set to 60min. Since the horizontal diffusion has been tested at a time where SNAP was run with ~50km resolution meteorology, 15min timesteps were common, so the original horizontal diffusion was more similar to a setting with 15min base-time.
![snap_new_diffusion_15minhdiff_high nc_scatter](https://user-images.githubusercontent.com/2852979/217784061-eb748395-ddd3-4c82-9dcd-5dc86babaa9e.png)
The bias with the 15min baseline for the etex results (above) are just slightly worse than the bias with the 60min (below), and acceptable. 
![snap_new_diffusion_high nc_scatter](https://user-images.githubusercontent.com/2852979/217784065-8d2926e7-c6ae-4b41-bea0-8aab58ae8a97.png)
This PR partly reverts yesterdays horizontal diffusion change to a more conservative approach by not changing too much in SNAP without extensive testing.