### PR TITLE
atomic uploads using rsync

### DIFF
--- a/utils/SnapPy/Snappy/SnapJobEC.py
+++ b/utils/SnapPy/Snappy/SnapJobEC.py
@@ -100,7 +100,7 @@ chmod g+rw {rundir}/$JOB_NAME.$JOB_ID.logerr
 
 function send_status()
 {{
-    rsync -a -e 'ssh {sshoptions}' {statusfile} {scpdestination}
+    rsync --archive --rsh 'ssh {sshoptions}' {statusfile} {scpdestination}
 }}
 
 function send_msg()
@@ -137,7 +137,7 @@ if [ $? -ne 0 ]; then
     send_msg 410 "{model} internal error, zip failed"
     exit 1;
 fi
-rsync -a -e 'ssh {sshoptions}' {zipreturnfile} {scpdestination}
+rsync --archive --rsh 'ssh {sshoptions}' {zipreturnfile} {scpdestination}
 if [ $? -ne 0 ]; then
     send_msg 410 "{model} internal error copying data to destination"
     exit 1;

--- a/utils/SnapPy/Snappy/SnapJobEC.py
+++ b/utils/SnapPy/Snappy/SnapJobEC.py
@@ -100,7 +100,7 @@ chmod g+rw {rundir}/$JOB_NAME.$JOB_ID.logerr
 
 function send_status()
 {{
-    scp {scpoptions} {statusfile} {scpdestination}
+    rsync -a -e 'ssh {sshoptions}' {statusfile} {scpdestination}
 }}
 
 function send_msg()
@@ -137,7 +137,7 @@ if [ $? -ne 0 ]; then
     send_msg 410 "{model} internal error, zip failed"
     exit 1;
 fi
-scp {scpoptions} {zipreturnfile} {scpdestination}
+rsync -a -e 'ssh {sshoptions}' {zipreturnfile} {scpdestination}
 if [ $? -ne 0 ]; then
     send_msg 410 "{model} internal error copying data to destination"
     exit 1;
@@ -153,7 +153,7 @@ exit 0;
             zipreturnfile=self.get_return_filename(),
             model=self.task.model,
             statusfile=self.task.status_filename(),
-            scpoptions=self.task.scpoptions,
+            sshoptions=self.task.sshoptions,
             scpdestination=self.task.scpdestination,
             module_to_load=module_to_load,
             queue=queue,

--- a/utils/SnapPy/snapRemoteRunner.py
+++ b/utils/SnapPy/snapRemoteRunner.py
@@ -68,6 +68,7 @@ class SnapTask:
     model = typed_property("model", str)
     id = typed_property("id", str)
     scpdestination = typed_property("scpdestination", str)
+    sshoptions = typed_property("sshoptions", str)
     timestamp = typed_property("timestamp", datetime.datetime)
     rundir = typed_property("rundir", str)
     queue: str = typed_property("queue", str)
@@ -80,7 +81,7 @@ class SnapTask:
         model,
         ident,
         scpdestination,
-        scpoptions,
+        sshoptions,
         queue,
     ):
         self.topdir = topdir
@@ -89,7 +90,7 @@ class SnapTask:
         self.model = model
         self.id = ident
         self.scpdestination = scpdestination
-        self.scpoptions = scpoptions
+        self.sshoptions = sshoptions,
         self.timestamp = datetime.datetime.now()
         self.queue = queue
 
@@ -373,7 +374,7 @@ class SnapRemoteRunner:
                         ident=m.group(1),
                         model=m.group(2),
                         scpdestination=self.scpdestination,
-                        scpoptions=" ".join(self.ssh.scp_options),
+                        sshoptions=" ".join(self.ssh.ssh_options),
                         queue=self.queue,
                     )
                     if task.is_complete(reldir=self.UPLOAD_DIR):


### PR DESCRIPTION
Downloads may fail if file-upload has not finished completely. Using rsync for atomic uploads (tempfile+move) instead of scp.