### PR TITLE
Smaller graphics fixes

### DIFF
--- a/install_usermodule_r8.sh
+++ b/install_usermodule_r8.sh
@@ -31,7 +31,7 @@ singularity exec \
     --env QT_QPA_PLATFORMTHEME='' \
     --env QT_QPA_FONTDIR='/usr/share/fonts/truetype' \
     --env QT_QPA_PLATFORM='offscreen' \
-    /modules/singularityrepo/fou/kl/atom/bdiana_3.57.13.sif bdiana \$@
+    /modules/singularityrepo/fou/kl/atom/diana_3.58.0.sif bdiana \$@
 EOF
     chmod +x -- "$1/bin/bdiana"
 }
@@ -65,6 +65,8 @@ install_bsnap() {
     ln --symbolic --force -- gcc_pkgconfig.mk current.mk
     make clean
     env VERSION="$MODULE_VERSION" make -j 4 BINDIR="$MODULE_PREFIX"/bin install
+
+    install_bdiana $MODULE_PREFIX
 }
 
 install_baseenv() {
@@ -82,7 +84,6 @@ install_baseenv() {
     install_conda_env "$MODULE_PREFIX"
     conda activate "$MODULE_PREFIX"
     patch_fimex_pkgconfig
-    install_bdiana $MODULE_PREFIX
 
     MODULEFILE=/modules/MET/rhel8/user-modules/fou-modules/SnapPy/"$MODULE_VERSION"
 

--- a/install_usermodule_r8.sh
+++ b/install_usermodule_r8.sh
@@ -22,7 +22,7 @@ install_bdiana() {
     cat > "$1/bin/bdiana" <<EOF
 #! /bin/bash
 module use /modules/MET/rhel8/user-modules/
-module load singularity/3.10.5
+module load --silent singularity/3.11.3
 
 singularity exec \
     --no-home --bind /lustre/\${STORE}:/lustre/\${STORE} \

--- a/src/common/fimex.f90
+++ b/src/common/fimex.f90
@@ -57,6 +57,17 @@ MODULE Fimex
     CDM_UINT64
   END ENUM
 
+  !> Logging levels
+  !! These are the same as #Logger::LogLevel in Logger.h
+  ENUM, BIND(C)
+    ENUMERATOR :: LOGLEVEL_OFF = 1000,&
+        LOGLEVEL_FATAL = 900,&
+        LOGLEVEL_ERROR = 800,&
+        LOGLEVEL_WARN = 700,&
+        LOGLEVEL_INFO = 600,&
+        LOGLEVEL_DEBUG = 500
+  END ENUM
+
   !> Class to store file-handles for the high-level API.
   !! @warning The class FimexIO stores internally two refernces to file and data-handles.
   !!    It should therefore not be accessed from two parallel threads
@@ -340,6 +351,13 @@ MODULE Fimex
       IMPLICIT NONE
       TYPE(C_PTR),INTENT(IN),VALUE    :: io
     END SUBROUTINE c_mifi_free_cdm_reader
+
+    !> F90-wrapper for Logger::defaultLogLevel(...)
+    SUBROUTINE c_mifi_set_default_log_level(loglevel) BIND(C,NAME="mifi_set_default_log_level")
+      USE iso_c_binding,     ONLY: C_INT
+      IMPLICIT NONE
+      INTEGER(C_INT),INTENT(IN),VALUE        :: loglevel
+    END SUBROUTINE c_mifi_set_default_log_level
   END INTERFACE
 
   CONTAINS
@@ -660,13 +678,15 @@ MODULE Fimex
 
     c_pos = pos - 1
     get_dimname = ""
-    IF ( C_ASSOCIATED(this%sb) .AND. pos <= c_mifi_slicebuilder_ndims(this%sb) ) THEN
+    IF (C_ASSOCIATED(this%sb)) THEN
+      IF (pos <= c_mifi_slicebuilder_ndims(this%sb)) THEN
        i = c_mifi_slicebuilder_dimname(this%sb, c_pos, var_array, 1025)
        IF (i >= 2) THEN
           i = i - 1
           get_dimname(1:i) = var_array(1:i)
        ENDIF
     ENDIF
+ENDIF
     RETURN
   END FUNCTION get_dimname
 
@@ -958,4 +978,16 @@ MODULE Fimex
     INTEGER           :: x
     x = this%close ()
   END SUBROUTINE destructor
+
+  !> Set default loglevel
+  !! @param loglevel one of LOGLEVEL_*
+  SUBROUTINE set_default_log_level(loglevel)
+    USE iso_c_binding,                ONLY: C_INT
+    IMPLICIT NONE
+    INTEGER, INTENT(IN)                  :: loglevel
+
+    CALL c_mifi_set_default_log_level(loglevel)
+  END SUBROUTINE
+
+
 END MODULE Fimex

--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -200,6 +200,7 @@ PROGRAM bsnap
 #if defined(FIMEX)
   USE readfield_fiML, only: readfield_fi
   USE filesort_fiML, only: filesort_fi
+  use Fimex, only: fimex_set_loglevel => set_default_log_level, FIMEX_LOGLEVEL_WARN => LOGLEVEL_WARN
 #endif
   USE releasefileML, only: releasefile
   USE filesort_ncML, only: filesort_nc
@@ -282,6 +283,10 @@ PROGRAM bsnap
   character(len=*), parameter :: VERSION_ = VERSION
 #else
   character(len=*), parameter :: VERSION_ = "UNVERSIONED"
+#endif
+
+#if defined(FIMEX)
+  call fimex_set_loglevel(FIMEX_LOGLEVEL_WARN)
 #endif
 
   if (command_argument_count() < 1) then

--- a/utils/SnapPy/Snappy/Resources.py
+++ b/utils/SnapPy/Snappy/Resources.py
@@ -78,8 +78,7 @@ class Resources(ResourcesCommon):
 
     _MET_INPUTDIRS = {
         MetModel.Meps2p5: [
-            "{LUSTREDIR}/immutable/archive/projects/metproduction/MEPS/",
-            "{LUSTREDIR}/project/fou/kl/cerad/Projects/2022_ArcticReihn/Meteo/MEPS/"
+            "{LUSTREDIR}/immutable/archive/projects/metproduction/MEPS/"
         ],
         MetModel.GfsGribFilter: ["/disk1/tmp/"],
     }

--- a/utils/SnapPy/Snappy/SnapController.py
+++ b/utils/SnapPy/Snappy/SnapController.py
@@ -195,7 +195,7 @@ class SnapController:
             os.mkdir(prod_dir)
             with open(os.path.join(prod_dir, "diana.setup"), "wt") as fh:
                 di_setup = f"""
-%include /etc/diana/setup/diana.setup-COMMON
+%include /etc/diana/$(PVERSION)/diana.setup-COMMON
 <COLOURS>
 seablueOSM=174,207,224
 landOSM=242,239,233

--- a/utils/SnapPy/Snappy/resources/snap.in
+++ b/utils/SnapPy/Snappy/resources/snap.in
@@ -22,7 +22,7 @@ FIELD  model=SNAP.current plot={component}_acc_total_deposition colour=off plott
 OBS plot=EuropeISO3 data=EuropeISO3 parameter=Name colour=grey50 density=1 image=off orientation=horizontal scale=1.2 tempprecision=true timediff=60
 AREA name={areaname}
 MAP map=Gshhs-Auto contour=on cont.colour=graywhite cont.linewidth=1 cont.linetype=solid cont.zorder=1 land=on land.colour=landOSM land.zorder=0 lon=off lat=off frame=off
-MAP map=Euro2 contour=on cont.colour=grey50 cont.linewidth=1 cont.linetype=solid cont.zorder=1 land=off lon=off lat=off frame=off
+MAP map=countries contour=on cont.colour=grey50 cont.linewidth=1 cont.linetype=solid cont.zorder=1 land=off lon=off lat=off frame=off
 MAP backcolour=seablueOSM map=Fylker contour=on cont.colour=gray cont.linewidth=1 cont.linetype=solid cont.zorder=1 land=off lon=on lon.colour=lightgray lon.linewidth=1 lon.linetype=solid lon.density=10 lon.zorder=2 lon.showvalue=off lon.value_pos=bottom lon.fontsize=10 lat=on lat.colour=lightgray lat.linewidth=1 lat.linetype=solid lat.density=10 lat.zorder=2 lat.showvalue=off lat.value_pos=left lat.fontsize=10 frame=off
 LABEL data font=BITMAPFONT fontsize=8
 LABEL text="$day $date $auto UTC" tcolour=red bcolour=black fcolour=white:200 polystyle=both halign=left valign=top font=BITMAPFONT fontsize=8
@@ -38,7 +38,7 @@ FIELD model=SNAP.current plot=TimeOfArrival colour=off plottype=contour linetype
 OBS plot=EuropeISO3 data=EuropeISO3 parameter=Name colour=grey50 density=1 image=off orientation=horizontal scale=1.2 tempprecision=true timediff=60
 AREA name={areaname}
 MAP map=Gshhs-Auto contour=on cont.colour=graywhite cont.linewidth=1 cont.linetype=solid cont.zorder=1 land=on land.colour=landOSM land.zorder=0 lon=off lat=off frame=off
-MAP map=Euro2 contour=on cont.colour=grey50 cont.linewidth=1 cont.linetype=solid cont.zorder=1 land=off lon=off lat=off frame=off
+MAP map=countries contour=on cont.colour=grey50 cont.linewidth=1 cont.linetype=solid cont.zorder=1 land=off lon=off lat=off frame=off
 MAP backcolour=seablueOSM map=Fylker contour=on cont.colour=gray cont.linewidth=1 cont.linetype=solid cont.zorder=1 land=off lon=on lon.colour=lightgray lon.linewidth=1 lon.linetype=solid lon.density=10 lon.zorder=2 lon.showvalue=off lon.value_pos=bottom lon.fontsize=10 lat=on lat.colour=lightgray lat.linewidth=1 lat.linetype=solid lat.density=10 lat.zorder=2 lat.showvalue=off lat.value_pos=left lat.fontsize=10 frame=off
 LABEL data font=BITMAPFONT fontsize=8
 LABEL text="$day $date $auto UTC" tcolour=red bcolour=black fcolour=white:200 polystyle=both halign=left valign=top font=BITMAPFONT fontsize=8

--- a/utils/SnapPy/snapEnsPlot.py
+++ b/utils/SnapPy/snapEnsPlot.py
@@ -23,9 +23,29 @@ import logging
 logging.root.setLevel(logging.ERROR)
 
 def plotMap(data, x, y, ax, title="", title_loc="center", clevs=[10,100,300,1000,3000,10000,30000,100000, 300000, 10000000], colors=None, extend='max'):
-    ax.add_feature(cartopy.feature.GSHHSFeature(scale='low', facecolor='none', edgecolor='whitesmoke', linewidth=.2), zorder=100)
-    ax.add_feature(cartopy.feature.BORDERS, edgecolor="lightgray", linewidth=.5, zorder=100) 
-    #ax.gridlines(draw_labels=True)
+    ax.set_facecolor("#f2efe9") # background, osm-land
+    ax.add_feature(cartopy.feature.NaturalEarthFeature(
+            category='physical',
+            name='ocean',
+            scale='50m',
+            facecolor="#aecfe0"),edgecolor="none", zorder=10) # #aecfe0 = osm-ocean
+    # ax.add_feature(cartopy.feature.NaturalEarthFeature(
+    #     category='physical',
+    #     name='land',
+    #     scale='50m',
+    #     facecolor='none'),edgecolor="black", linewidth=.5, zorder=10)
+    ax.add_feature(cartopy.feature.NaturalEarthFeature(
+        category='physical',
+        name='lakes',
+        scale='10m',
+        facecolor='#aecfe0'),edgecolor="whitesmoke", linewidth=.2, zorder=20)
+    ax.add_feature(cartopy.feature.NaturalEarthFeature(
+        category='cultural',
+        #name='admin_0_boundary_lines_land',
+        name='admin_0_countries_deu',
+        scale='10m',
+        facecolor='none'),edgecolor="lightgray", linewidth=.5, zorder=100)
+
     ax.gridlines(edgecolor="lightgray", linewidth=.3, zorder=100)
 
     ny = data.shape[0]
@@ -36,9 +56,6 @@ def plotMap(data, x, y, ax, title="", title_loc="center", clevs=[10,100,300,1000
     cs = ax.contourf(x,y,data,clevs,colors=colors, extend=extend, zorder=50)
     # add title
     ax.set_title(title, loc=title_loc)
-    ax.add_feature(cartopy.feature.OCEAN,facecolor="#aecfe0", edgecolor='none', zorder=10) # #aecfe0 = osm-sea
-    ax.add_feature(cartopy.feature.LAND, facecolor="#f2efe9", edgecolor='none', zorder=10) # f2efe9 = osm-land
-    ax.add_feature(cartopy.feature.LAKES,facecolor="#aecfe0", edgecolor='whitesmoke', linewidth=.2, zorder=20)
     return cs
 
 
@@ -266,7 +283,7 @@ def snapens(ncfiles, hour, outfile):
     fig.subplots_adjust(hspace=0.12, wspace=0.01)
     fig.savefig(outfile, bbox_inches='tight')
 
-    
+
 
 if __name__ == "__main__":
     os.umask(0o002)

--- a/utils/SnapPy/snapEnsPlot.py
+++ b/utils/SnapPy/snapEnsPlot.py
@@ -23,17 +23,12 @@ import logging
 logging.root.setLevel(logging.ERROR)
 
 def plotMap(data, x, y, ax, title="", title_loc="center", clevs=[10,100,300,1000,3000,10000,30000,100000, 300000, 10000000], colors=None, extend='max'):
-    ax.set_facecolor("#f2efe9") # background, osm-land
+    ax.set_facecolor("#f2efe9") # background, osm-land color
     ax.add_feature(cartopy.feature.NaturalEarthFeature(
             category='physical',
             name='ocean',
             scale='50m',
-            facecolor="#aecfe0"),edgecolor="none", zorder=10) # #aecfe0 = osm-ocean
-    # ax.add_feature(cartopy.feature.NaturalEarthFeature(
-    #     category='physical',
-    #     name='land',
-    #     scale='50m',
-    #     facecolor='none'),edgecolor="black", linewidth=.5, zorder=10)
+            facecolor="#aecfe0"),edgecolor="none", zorder=10) # osm-ocean color
     ax.add_feature(cartopy.feature.NaturalEarthFeature(
         category='physical',
         name='lakes',
@@ -41,7 +36,6 @@ def plotMap(data, x, y, ax, title="", title_loc="center", clevs=[10,100,300,1000
         facecolor='#aecfe0'),edgecolor="whitesmoke", linewidth=.2, zorder=20)
     ax.add_feature(cartopy.feature.NaturalEarthFeature(
         category='cultural',
-        #name='admin_0_boundary_lines_land',
         name='admin_0_countries_deu',
         scale='10m',
         facecolor='none'),edgecolor="lightgray", linewidth=.5, zorder=100)


### PR DESCRIPTION
This PM allows SnapPy to plot with a newer bdiana version with de jure rather than de facto country-borders. In addition, country-codes are plotted again, and a test-dataset is removed.

PS: Sorry, the branch-name is completely misleading, this branch has nothing to do with meps.