### PR TITLE
Implement changes in Ash emissions and products following VAAC London

### DIFF
--- a/utils/SnapPy/Snappy/EEMEP/Controller.py
+++ b/utils/SnapPy/Snappy/EEMEP/Controller.py
@@ -265,6 +265,18 @@ class Controller():
             errors += str(ex) + "\n"
             errors += 'Please select Height and Type (Advanced) manually.\n'
 
+        # fine-ash fraction (particles < 63µm)
+        try:
+            m63 = qDict['m63']
+            if m63.lower() == 'mastin':
+                m63f = volctype['m63']
+            else:
+                m63f = float(m63)
+                if not (0 < m63f <= 1):
+                    raise Exception(f"fine-ash fraction out of range 0-1: {m63f}")
+        except Exception as ex:
+            errors += str(ex) + "\n"
+
         self.write_log("working with {:s} (lat={:.2f}N lon={:.2f}E) starting at {:s}".format(volcano, latf, lonf, startTime))
 
 
@@ -326,7 +338,7 @@ class Controller():
                                          bottom=0,
                                          top=cheight,
                                          rate=rate,
-                                         m63=volctype['m63']))
+                                         m63=m63f))
 
         self.lastOutputDir = os.path.join(self.res.getOutputDir(), "{0}_ondemand".format(volcano))
         self.volcano_file = os.path.join(self.lastOutputDir, ModelRunner.VOLCANO_FILENAME)

--- a/utils/SnapPy/Snappy/EEMEP/SixHourMax.py
+++ b/utils/SnapPy/Snappy/EEMEP/SixHourMax.py
@@ -40,11 +40,13 @@ class SixHourMax:
 i.e. calculate the 6hour mean of the last six hours (running) (average also the surface pressure)
      retrieve the max value within the fat flight layers (FL == atmospheric pressure altitude above 1013.25hPa) (0-200, 200-350, 350-550)
 
-     Multiply by 10, to match observations from Eyjafjella. (https://www.mdpi.com/2073-4433/11/4/352 Becket et al. 2020 (VAAC developments))
+     The peak to mean factor, which was 10 for Eyjafjella is now set to 1 following
+      (https://www.mdpi.com/2073-4433/11/4/352 Becket et al. 2020 (VAAC developments))
     """
     # performance option
     USE_2D = False
     FL = (200, 350, 550)
+    PEAK_TO_MEAN_CALIBRATION = 1.
     SNAP_ASH_CONC_PATTERN = re.compile(r"ASH_\d+_concentration_ml")
     SNAP_ASH_COL_PATTERN = re.compile(r"ASH_\d+_column_concentration")
 
@@ -213,10 +215,10 @@ i.e. calculate the 6hour mean of the last six hours (running) (average also the 
                 max550 = np.max(asha, axis=0, where=(pFL[1] >= pal) & (pFL[2] < pal), initial=0)
 
 
-            # add factor 10 for obs/model differences
-            v200[t,:] = max200 * 10.
-            v350[t,:] = max350 * 10.
-            v550[t,:] = max550 * 10.
+            # use factor for obs/model differences
+            v200[t,:] = max200 * self.PEAK_TO_MEAN_CALIBRATION
+            v350[t,:] = max350 * self.PEAK_TO_MEAN_CALIBRATION
+            v550[t,:] = max550 * self.PEAK_TO_MEAN_CALIBRATION
             nc.sync()
 
         self._snap_add_total_ash_column()

--- a/utils/SnapPy/Snappy/EEMEP/resources/startScreenVolc.html
+++ b/utils/SnapPy/Snappy/EEMEP/resources/startScreenVolc.html
@@ -78,7 +78,7 @@ function toggle_advanced_sourceterm() {
         <input type="submit" name="action" value="Cancel submitted" />
      </fieldset>
     </form>
-     
+
   </div>
 
 </div>
@@ -107,7 +107,7 @@ function toggle_advanced_sourceterm() {
          <div style="float:right;">
            <input type="checkbox" name="restart_file" value="true">
          </div>
-         
+
          <br clear="both" style="clear:both;"/>
          <label>Volcano-Type: </label>
          <div style="float:right;">
@@ -116,7 +116,14 @@ function toggle_advanced_sourceterm() {
            %VOLCANOTYPE_OPTIONS%
          </select>
          </div>
-         
+
+         <br clear="both" style="clear:both;"/>
+         <span title="decimal between 0 and 1, or Mastin"><label>Fine-Ash Fraction:</label>
+           <div style="float:right;">
+            <input name="m63" type="text" size="6" maxlength="6" value="0.05">
+           </div>
+         </span>
+
          <br clear="both" style="clear:both;"/>
          <label>MET-MODEL:</label>
            <div style="float:right;">
@@ -124,8 +131,8 @@ function toggle_advanced_sourceterm() {
                <option selected="selected" value="nrpa_ec_0p1">EC 0.1, NRPA-domain</option>
              </select>
            </div>
-         
-           
+
+
          <br clear="both" style="clear:both;"/>
          <label>EC-Model Runtime:</label>
          <div style="float:right;">
@@ -137,7 +144,7 @@ function toggle_advanced_sourceterm() {
 
          </div>
          </fieldset>
-         
+
          <p>Volcanoes<br>
          <select name="volcano" size="20">
              <option selected="selected" value="">Use Lat-Lon</option>

--- a/utils/SnapPy/debian.jammy/control
+++ b/utils/SnapPy/debian.jammy/control
@@ -8,5 +8,5 @@ Standards-Version: 3.9.7
 
 Package: snap-py
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends}, bsnap (>= 2.3.0), python3-pyqt5, python3-pyqt5.qtwebkit, python3-netcdf4
+Depends: ${misc:Depends}, ${python3:Depends}, bsnap (>= 2.3.0), python3-pyqt5, python3-pyqt5.qtwebkit, python3-netcdf4, python3-pyproj
 Description: SNAP GUI in python


### PR DESCRIPTION
Using a default of 0.05 for fine-ash fraction and a peak to mean ratio of 1 for ash-calculations following

Beckett, F.M.; Witham, C.S.; Leadbetter, S.J.; Crocker, R.; Webster, H.N.; Hort, M.C.; Jones, A.R.; Devenish, B.J.; Thomson, D.J. Atmospheric Dispersion Modelling at the London VAAC: A Review of Developments since the 2010 Eyjafjallajökull Volcano Ash Cloud. Atmosphere 2020, 11, 352. https://doi.org/10.3390/atmos11040352 

Allowing manually change of fine-ash fraction in user interface to either a new value or to original default, i.e. taken from Mastin et al (2009b) Table 3.