### PR TITLE
Simplify klevel/remove kadd

### DIFF
--- a/src/common/bldp.f90
+++ b/src/common/bldp.f90
@@ -39,7 +39,7 @@ module bldpML
 subroutine bldp
   USE snapdimML, only: nx,ny,nk
   USE snaptabML, only: cp, g, pmult, pitab
-  USE snapgrdML, only: ahalf, bhalf, vhalf, alevel, blevel, kadd
+  USE snapgrdML, only: ahalf, bhalf, vhalf, alevel, blevel
   USE snapfldML, only: u2, v2, ps2, t2, hbl2, bl2
   USE ftestML, only: ftest
   USE snapdebug, only: iulog
@@ -80,7 +80,7 @@ subroutine bldp
   if(pblbot > p) pblbot=p
   kbltop=2
   kblbot=2
-  nkk=min(nk-2,nk-kadd)
+  nkk=min(nk-2,nk)
   do k=2,nkk
     p=ahalf(k)+bhalf(k)*psurf
     if(p > pbltop) kbltop=k+1

--- a/src/common/find_parameters.f90
+++ b/src/common/find_parameters.f90
@@ -345,6 +345,7 @@ contains
     integer :: ncid
     integer :: hybrid_dimid, hybrid_len
     integer :: i
+    integer :: nk
     stat = 0
 
     stat = nf90_open(ncfile, NF90_NOWRITE, ncid)
@@ -362,10 +363,11 @@ contains
       dummy_int = nf90_close(ncid)
       return
     endif
-    allocate (klevel(hybrid_len+1))
+    nk = hybrid_len + 1
+    allocate(klevel(nk))
     klevel(1) = 0
-    do i = 1, hybrid_len
-      klevel(i+1) = (hybrid_len+1) - i
+    do i = 2, nk
+      klevel(i) = nk - i + 1
     enddo
   end subroutine
 end module

--- a/src/common/find_parameters.f90
+++ b/src/common/find_parameters.f90
@@ -330,7 +330,7 @@ contains
 
   !> Forms the k-levels to search, starting from max
   !> of the hybrid dimension, to 1, skipping 0
-  subroutine get_klevel(ncfile, klevel, stat)
+  subroutine get_klevel(ncfile, klevel, surface_index, stat)
     !> path to nc file
     character(len=*), intent(in) :: ncfile
     !> resulting klevels, ranging from 0 to len(hybrid)
@@ -338,6 +338,8 @@ contains
     !>
     !> 0, nk, nk-1, ..., 1
     integer, allocatable, intent(out) :: klevel(:)
+    !> surface index for this meteorology
+    integer, intent(out) :: surface_index
     !> error code (0 for success)
     integer, intent(out) :: stat
 
@@ -363,6 +365,7 @@ contains
       dummy_int = nf90_close(ncid)
       return
     endif
+    surface_index = hybrid_len
     nk = hybrid_len + 1
     allocate(klevel(nk))
     klevel(1) = 0

--- a/src/common/find_parameters_fi.f90
+++ b/src/common/find_parameters_fi.f90
@@ -142,10 +142,11 @@ contains
       deallocate(klevel)
     endif
 
-    allocate (klevel(nk+1))
+    nk = nk + 1
+    allocate(klevel(nk))
     klevel(1) = 0
-    do i = 1, nk
-      klevel(i+1) = (nk+1) - i
+    do i = 2, nk
+      klevel(i) = nk - i + 1
     enddo
 
     stat = fio%close()

--- a/src/common/find_parameters_fi.f90
+++ b/src/common/find_parameters_fi.f90
@@ -43,7 +43,7 @@ contains
   !> Tries to detect grid parameters given by the
   !> netcdf file, taking the projection from
   !> the varname
-  subroutine detect_gridparams_fi(file, varname, nx, ny, igtype, gparam, klevel, stat)
+  subroutine detect_gridparams_fi(file, varname, nx, ny, igtype, gparam, klevel, surface_index, stat)
     !> Path to the netcdf file
     character(len=*), intent(in) :: file
     character(len=*), intent(in) :: varname
@@ -65,6 +65,8 @@ contains
     !> of the hybrid dimension, to 1, skipping 00
     !> nk, nk-1, ..., 1
     integer, allocatable, intent(out) :: klevel(:)
+    !> Index of surface level
+    integer, intent(out) :: surface_index
     !> Error code, 0 for success
     integer, intent(out) :: stat
 
@@ -108,6 +110,7 @@ contains
     nx = length(xpos)
     ny = length(ypos)
     nk = length(kpos)
+    surface_index = nk
     xdim = fio%get_dimname(xpos)
     ydim = fio%get_dimname(ypos)
     kdim = fio%get_dimname(kpos)
@@ -142,6 +145,7 @@ contains
       deallocate(klevel)
     endif
 
+    ! Add the surface level
     nk = nk + 1
     allocate(klevel(nk))
     klevel(1) = 0

--- a/src/common/om2edot.f90
+++ b/src/common/om2edot.f90
@@ -55,7 +55,7 @@ module om2edotML
 !>                 More than half of the model levels and the upper
 !>                 level are required.
 subroutine om2edot
-  USE snapgrdML, only: ahalf, bhalf, vhalf, kadd, klevel, gparam
+  USE snapgrdML, only: ahalf, bhalf, vhalf, klevel, gparam
   USE snapfldML, only: xm, ym, ps2, u2, v2, w2, field1, field2, field3, field4
   USE snapdimML, only: nx,ny,nk
   USE snapdebug, only: iulog
@@ -67,7 +67,7 @@ subroutine om2edot
 
   write(iulog,*) 'OM2EDOT'
 
-  do k=2,nk-kadd
+  do k=2,nk
 
     deta=vhalf(k-1)-vhalf(k)
 
@@ -85,11 +85,11 @@ subroutine om2edot
 !..check if required model levels are present for subr. edcomp
 
 !..no. of present levels
-  kk=(nk-kadd)-1
+  kk=(nk)-1
 !..assuming that the lower model level is always present above surface level
   km=klevel(2)
 
-  if(kk > km/2 .AND. kadd == 0 .AND. klevel(nk) == 1) then
+  if(kk > km/2 .AND. klevel(nk) == 1) then
 
     d2hx=1./(gparam(7)*2.)
     d2hy=1./(gparam(8)*2.)

--- a/src/common/readfield_fi.f90
+++ b/src/common/readfield_fi.f90
@@ -72,7 +72,7 @@ contains
       hlayer1, hlayer2, bl1, bl2, enspos, precip, t1_abs, t2_abs, &
       field1
     USE snapgrdML, only: alevel, blevel, vlevel, ahalf, bhalf, vhalf, &
-                         gparam, kadd, klevel, ivlevel, imslp, igtype, ivlayer, ivcoor
+                         gparam, klevel, ivlevel, imslp, igtype, ivlayer, ivcoor
     USE snapmetML, only: met_params, xy_wind_units, pressure_units, omega_units, &
                          sigmadot_units, temp_units, requires_precip_deaccumulation
     USE snapdimML, only: nx, ny, nk, output_resolution_factor, hres_field
@@ -215,7 +215,7 @@ contains
     end if
 
     ptop = 100.0
-    do k = nk - kadd, 2, -1
+    do k = nk , 2, -1
 
       !..input model level no.
       ilevel = klevel(k)
@@ -269,7 +269,7 @@ contains
         end if
       end if
 
-    end do ! k=nk-kadd,2,-1
+    end do ! k=nk,2,-1
 
 !..surface pressure, 10m wind and possibly mean sea level pressure,
 !..precipitation
@@ -333,7 +333,7 @@ contains
     if (met_params%temp_is_abs) then
       if (allocated(t2_abs)) t2_abs(:,:,:) = t2
       !..abs.temp. -> pot.temp.
-      do k = 2, nk - kadd
+      do k = 2, nk
         do j = 1, ny
           do i = 1, nx
             p = alevel(k) + blevel(k)*ps2(i,j)
@@ -344,7 +344,7 @@ contains
     else
       if (allocated(t2_abs)) then
         ! pot.temp -> abs.temp
-        do k=2,nk-kadd
+        do k=2,nk
           do j = 1, ny
             do i = 1, nx
               p = alevel(k) + blevel(k)*ps2(i,j)
@@ -370,19 +370,6 @@ contains
 
 !..no temperature at or near surface (not used, yet)
     t2(:, :, 1) = -999.0
-    if (kadd > 0) then
-      !..levels added at the top
-      dred = 0.5/float(kadd)
-      red = 1.
-      kk = nk - kadd
-      do k = nk - kadd + 1, nk
-        red = red - dred
-        u2(:, :, k) = u2(:, :, kk)
-        v2(:, :, k) = v2(:, :, kk)
-        w2(:, :, k) = w2(:, :, kk)*red
-        t2(:, :, k) = t2(:, :, kk)
-      end do
-    end if
 
     if (backward) then
       ! backward-calculation, switch sign of winds

--- a/src/common/readfield_fi.f90
+++ b/src/common/readfield_fi.f90
@@ -103,8 +103,8 @@ contains
     integer :: i, j, k, ilevel, i1, i2
     integer :: nhdiff, nhdiff_precip, prev_tstep_same_file
     real :: alev(nk), blev(nk), dxgrid, dygrid
-    integer :: kk, ifb, kfb
-    real :: dred, red, p, px, ptop
+    integer :: ifb, kfb
+    real :: p, px, ptop
     real :: ptoptmp(1)
 
     integer :: timepos, timeposm1, nr

--- a/src/common/readfield_fi.f90
+++ b/src/common/readfield_fi.f90
@@ -75,7 +75,7 @@ contains
                          gparam, klevel, ivlevel, imslp, igtype, ivlayer, ivcoor
     USE snapmetML, only: met_params, xy_wind_units, pressure_units, omega_units, &
                          sigmadot_units, temp_units, requires_precip_deaccumulation
-    USE snapdimML, only: nx, ny, nk, output_resolution_factor, hres_field
+    USE snapdimML, only: nx, ny, nk, output_resolution_factor, hres_field, surface_index
     USE datetime, only: datetime_t, duration_t
     USE readfield_ncML, only: find_index, compute_vertical_coords
 !> current timestep (always positive), negative istep means reset
@@ -283,8 +283,11 @@ contains
       call fi_checkload(fio, met_params%xwind10mv, xy_wind_units, u2(:, :, 1), nt=timepos, nr=nr, nz=1)
       call fi_checkload(fio, met_params%ywind10mv, xy_wind_units, v2(:, :, 1), nt=timepos, nr=nr, nz=1)
     else
-      call fi_checkload(fio, met_params%xwindv, xy_wind_units, u2(:, :, 1), nt=timepos, nr=nr, nz=nk-1)
-      call fi_checkload(fio, met_params%ywindv, xy_wind_units, v2(:, :, 1), nt=timepos, nr=nr, nz=nk-1)
+      if (surface_index <= 0) then
+        error stop "Surface index is invalid"
+      endif
+      call fi_checkload(fio, met_params%xwindv, xy_wind_units, u2(:, :, 1), nt=timepos, nr=nr, nz=surface_index)
+      call fi_checkload(fio, met_params%ywindv, xy_wind_units, v2(:, :, 1), nt=timepos, nr=nr, nz=surface_index)
     endif
 
 !..mean sea level pressure, not used in computations,

--- a/src/common/readfield_fi.f90
+++ b/src/common/readfield_fi.f90
@@ -283,8 +283,8 @@ contains
       call fi_checkload(fio, met_params%xwind10mv, xy_wind_units, u2(:, :, 1), nt=timepos, nr=nr, nz=1)
       call fi_checkload(fio, met_params%ywind10mv, xy_wind_units, v2(:, :, 1), nt=timepos, nr=nr, nz=1)
     else
-      call fi_checkload(fio, met_params%xwindv, xy_wind_units, u2(:, :, 1), nt=timepos, nr=nr, nz=nk)
-      call fi_checkload(fio, met_params%ywindv, xy_wind_units, v2(:, :, 1), nt=timepos, nr=nr, nz=nk)
+      call fi_checkload(fio, met_params%xwindv, xy_wind_units, u2(:, :, 1), nt=timepos, nr=nr, nz=nk-1)
+      call fi_checkload(fio, met_params%ywindv, xy_wind_units, v2(:, :, 1), nt=timepos, nr=nr, nz=nk-1)
     endif
 
 !..mean sea level pressure, not used in computations,

--- a/src/common/readfield_nc.f90
+++ b/src/common/readfield_nc.f90
@@ -117,7 +117,7 @@ subroutine readfield_nc(istep, backward, itimei, ihr1, ihr2, &
   USE snapgrdML, only: alevel, blevel, vlevel, ahalf, bhalf, vhalf, &
       gparam, klevel, ivlevel, imslp, igtype, ivlayer, ivcoor
   USE snapmetML, only: met_params, requires_precip_deaccumulation
-  USE snapdimML, only: nx, ny, nk, output_resolution_factor, hres_field
+  USE snapdimML, only: nx, ny, nk, output_resolution_factor, hres_field, surface_index
   USE datetime, only: datetime_t, duration_t
 !> current timestep (always positive), negative istep means reset
   integer, intent(in) :: istep
@@ -345,14 +345,14 @@ subroutine readfield_nc(istep, backward, itimei, ihr1, ihr2, &
     call nfcheckload(ncid, met_params%ywind10mv, start3d, count3d, v2(:,:,1))
   else
     if (enspos >= 0) then
-      call nfcheckload(ncid, met_params%xwindv, [1, 1, enspos+1, nk, timepos], &
+      call nfcheckload(ncid, met_params%xwindv, [1, 1, enspos+1, surface_index, timepos], &
           [nx, ny, 1, 1, 1], u2(:,:,1))
-      call nfcheckload(ncid, met_params%ywindv, [1, 1, enspos+1, nk, timepos], &
+      call nfcheckload(ncid, met_params%ywindv, [1, 1, enspos+1, surface_index, timepos], &
           [nx, ny, 1, 1, 1], v2(:,:,1))
     else
-      call nfcheckload(ncid, met_params%xwindv, [1, 1, nk, timepos], &
+      call nfcheckload(ncid, met_params%xwindv, [1, 1, surface_index, timepos], &
           [nx, ny, 1, 1], u2(:,:,1))
-      call nfcheckload(ncid, met_params%ywindv, [1, 1, nk, timepos], &
+      call nfcheckload(ncid, met_params%ywindv, [1, 1, surface_index, timepos], &
           [nx, ny, 1, 1], v2(:,:,1))
     endif
   endif

--- a/src/common/readfield_nc.f90
+++ b/src/common/readfield_nc.f90
@@ -143,8 +143,7 @@ subroutine readfield_nc(istep, backward, itimei, ihr1, ihr2, &
   integer :: i, j, k, ilevel, i1, i2
   integer :: nhdiff, nhdiff_precip
   real :: alev(nk), blev(nk), dxgrid, dygrid
-  integer :: kk
-  real :: dred, red, p, px, ptop
+  real :: p, px, ptop
   real :: ptoptmp(1)
   integer :: prev_tstep_same_file
 
@@ -913,7 +912,6 @@ subroutine compute_vertical_coords(alev, blev, ptop)
   real, intent(in) :: blev(:)
   real, intent(in) :: ptop
 
-  real :: db, dp, p1, p2
   integer :: k
 
   do k = 2, nk

--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -162,7 +162,7 @@ PROGRAM bsnap
   USE DateCalc, only: epochToDate, timeGM
   USE datetime, only: datetime_t, duration_t
   USE snapdebug, only: iulog, idebug, acc_timer => prefixed_accumulating_timer
-  USE snapdimML, only: nx, ny, nk, output_resolution_factor, ldata, maxsiz, mcomp
+  USE snapdimML, only: nx, ny, nk, output_resolution_factor, ldata, maxsiz, mcomp, surface_index
   USE snapfilML, only: filef, itimer, ncsummary, nctitle, nhfmax, nhfmin, &
                        nctype, nfilef, simulation_start, spinup_steps
   USE snapfldML, only: nhfout, enspos
@@ -235,6 +235,7 @@ PROGRAM bsnap
   integer :: m, np, npl, nlevel, ifltim = 0
   logical :: synoptic_output = .false.
   integer :: k, ierror, i, n
+  integer, allocatable :: klevel_manual(:)
   integer :: ih
   integer :: idrydep = 0, wetdep_version = 0, idecay
   integer :: ntimefo
@@ -1585,20 +1586,20 @@ contains
         !..levels.input=<num_levels, 0,kk,k,k,k,....,1>
         !..levels.input=<num_levels, 0,kk,k,k,k,....,18>
         if (.not. has_value) goto 12
-        if (allocated(klevel)) then
+        if (allocated(klevel_manual)) then
           write (error_unit, *) "re-assigning levels"
-          DEALLOCATE(klevel, STAT=AllocateStatus)
+          DEALLOCATE(klevel_manual, STAT=AllocateStatus)
         end if
         read (cinput(pname_start:pname_end), *, err=12) nlevel
         nk = nlevel
-        ALLOCATE(klevel(nk), STAT=AllocateStatus)
+        ALLOCATE(klevel_manual(nk), STAT=AllocateStatus)
         IF (AllocateStatus /= 0) ERROR STOP AllocateErrorMessage
 
-        read (cinput(pname_start:pname_end), *, err=12) nlevel, (klevel(i), i=1, nlevel)
-        if (klevel(1) /= 0 .OR. klevel(2) == 0) goto 12
+        read (cinput(pname_start:pname_end), *, err=12) nlevel, (klevel_manual(i), i=1, nlevel)
+        if (klevel_manual(1) /= 0 .OR. klevel_manual(2) == 0) goto 12
 
         do i = nk - 1, 2, -1
-          if (klevel(i) <= klevel(i + 1)) goto 12
+          if (klevel_manual(i) <= klevel_manual(i + 1)) goto 12
         end do
       case ('forecast.hour.min')
         warning = .true.
@@ -1802,7 +1803,7 @@ contains
       endif
       if (ftype .eq. "fimex") then
 #ifdef FIMEX
-        call detect_gridparams_fi(filef(1), met_params%xwindv, nx, ny, igtype, gparam, klevel, ierror)
+        call detect_gridparams_fi(filef(1), met_params%xwindv, nx, ny, igtype, gparam, klevel, surface_index, ierror)
         if (ierror /= 0) then
           error stop "Could not detect gridparams"
         endif
@@ -1815,12 +1816,16 @@ contains
           error stop "Autodetection did not work (detect_gridparams)"
         endif
         if (.not.allocated(klevel)) then
-          call get_klevel(filef(1), klevel, ierror)
+          call get_klevel(filef(1), klevel, surface_index, ierror)
           if (ierror /= 0) then
             error stop "Autodetection did not work (klevel)"
           endif
         endif
       end if
+      if (allocated(klevel_manual)) then
+        deallocate(klevel)
+        call move_alloc(klevel_manual, klevel)
+      endif
       nk = size(klevel)
       write (error_unit, *) "autodetection of grid-param: ", gparam
     end if

--- a/src/common/snapdimML.f90
+++ b/src/common/snapdimML.f90
@@ -33,6 +33,8 @@ module snapdimML
   integer, save, public :: ny = nypre
 !> number of levels
   integer, save, public :: nk = nkpre
+!> Index of the surface level of the meteorology
+  integer, save, public :: surface_index = -1
 
 !> max. input field size (possibly larger than nx*ny)
   integer, save, public :: maxsiz

--- a/src/common/snapgrdML.f90
+++ b/src/common/snapgrdML.f90
@@ -22,7 +22,7 @@ module snapgrdML
 
 !> mapping from internal vertical coordinate to MET vertical coord
 !>
-!> sequence: bottom to top (kk,kk-1,....1)
+!> sequence: bottom to top (0,kk,kk-1,...,1)
 !>
 !> level no.  1 should be 0    (surface fields here)
 !>
@@ -113,10 +113,6 @@ module snapgrdML
 !> * 2=sigma (Norlam)
 !> * 10=eta/hybrid   (Hirlam,...))
     integer, save, public :: ivcoor = 0
-!> levels added at the top (when missing upper model levels)
-!>
-!> (u,v copied up, w reduced, pot.temp. const.)
-    integer, save, public :: kadd
 !> table of level numbers for interpolation
 !>
 !> (key is vlevel*10000)

--- a/src/test/find_parameters_fi_test.f90
+++ b/src/test/find_parameters_fi_test.f90
@@ -12,6 +12,7 @@ program find_parameters_fi_test
   integer :: nx, ny
   integer :: igtype
   real :: gparam(6)
+  integer :: surface_index
 
   integer, allocatable :: klevel(:)
 
@@ -43,12 +44,13 @@ program find_parameters_fi_test
   end if
 
 
-  call detect_gridparams_fi(ncfile, varname, nx, ny, igtype, gparam, klevel, stat)
+  call detect_gridparams_fi(ncfile, varname, nx, ny, igtype, gparam, klevel, surface_index, stat)
   if (stat /= 0) error stop "Could not detect gridparams"
 
   write(*,*) "GRID.SIZE= ", nx, ny
   write(*,*) "IGTYPE= ", igtype
   write(*,*) "GRID PARAMS :", gparam
+  write(*,*) "SURFACE INDEX: ", surface_index
   write(*,*) "KLEVEL :", klevel
 
   ! call get_klevel_fi(ncfile, klevel, stat)


### PR DESCRIPTION
Simplifying the code for level selection by removing `kadd` functionality, I don't think we have used the `kadd` functionality in some time and I suspect it is broken

Fixes an off-by-one bug in using xwind as 10m wind, which causes issues for re-running ETEX