### PR TITLE
fix bomb-dose decay formula to start at H+1

### DIFF
--- a/src/common/release.f90
+++ b/src/common/release.f90
@@ -99,6 +99,9 @@ module releaseML
 !> max. no. of particles, total in all plumes, preset, can be configured in snap.input
   integer, save, public :: mpart = mpartpre
 
+!> seconds since start of run when bomb-release occurs
+  integer, save, public :: tpos_bomb = 0
+
   contains
 
 subroutine release(istep,nsteph,tf1,tf2,tnow,ierror)

--- a/src/common/snap.mk
+++ b/src/common/snap.mk
@@ -59,7 +59,7 @@ bldp.o: ../common/bldp.f90 snapdimML.o snaptabML.o snapgrdML.o snapfldML.o ftest
 	${F77} -c ${F77FLAGS} $(INCLUDES) $<
 particleML.o: ../common/particleML.f90
 	${F77} -c ${F77FLAGS} $<
-decay.o: ../common/decay.f90 particleML.o snapfldML.o snapparML.o
+decay.o: ../common/decay.f90 particleML.o snapfldML.o snapparML.o release.o
 	${F77} -c ${F77FLAGS} $(INCLUDES) $<
 compheight.o: ../common/compheight.f90 snapgrdML.o snapfldML.o snaptabML.o snapdimML.o ftest.o
 	${F77} -c ${F77FLAGS} $(INCLUDES) $<


### PR DESCRIPTION
Fix bomb-dose decay formula to start at H+1 with H+1 (1hour after bomb) emissions. No decay before H+1, which means that results the first hour are heavily underpredicted, which was expected anyway.

The old code applied the decay strength at H+1 to H+0, and at H+2 to H+1. Since the bomb-decay is a power and not a exponential decay, this was over-estimating decay by a factor ~2-3. In addition, it did not take into account releases occuring after model-start (full hour).

