### PR TITLE
fix rounding errors on release-steps close to model-time steps

### DIFF
--- a/src/common/release.f90
+++ b/src/common/release.f90
@@ -155,7 +155,7 @@ subroutine release(istep,nsteph,tf1,tf2,tnow,ierror)
   allocate( nrel(ncomp), nrel2(ncomp,2), relbq(ncomp), pbq(ncomp) )
 
   ! Release may occur first after simulation start
-  if (istep < releases(1)%frelhour*nsteph) then
+  if (istep < nint(releases(1)%frelhour*nsteph)) then
     return
   endif
 
@@ -163,7 +163,7 @@ subroutine release(istep,nsteph,tf1,tf2,tnow,ierror)
   !..single bomb release
     tstep=1.
   else
-    if (istep >= releases(size(releases))%frelhour*nsteph) then
+    if (istep >= nint(releases(size(releases))%frelhour*nsteph)) then
       return
     endif
     tstep=3600./float(nsteph)
@@ -172,7 +172,7 @@ subroutine release(istep,nsteph,tf1,tf2,tnow,ierror)
 
   nt=1
   do n=2,size(releases)
-    if(releases(n)%frelhour*nsteph <= istep) nt=n
+    if(nint(releases(n)%frelhour*nsteph) <= istep) nt=n
   end do
 
 

--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -1994,7 +1994,7 @@ contains
 
     integer, intent(out) :: ierror
 
-    integer :: i1
+    integer :: i1, interval
 
     logical :: error_release_profile
 
@@ -2101,11 +2101,13 @@ contains
     if (time_profile /= TIME_PROFILE_BOMB) then
       ! bomb releases everything at once, so the following check does not apply
       do i = 1, ntprof - 1
-        if ((releases(i + 1)%frelhour - releases(i)%frelhour)*3600 < tstep) then
+        interval = nint((releases(i + 1)%frelhour - releases(i)%frelhour)*3600)
+        if (interval < tstep) then
           warning = .true.
-          write (error_unit, *) "WARNING: Release interval is shorter than timestep; ", &
-            "some releases may be skipped"
-          exit
+          write (error_unit, *) "WARNING: Release interval", i, &
+            " is shorter than timestep: \n", interval, " < ", tstep, &
+            " some releases may be skipped"
+          !exit
         endif
       enddo
     end if


### PR DESCRIPTION
For very short release-step, e.g. equal to model-timesteps, 300s, rounding errors might skip a release. E.g. 300s release steps around model step 34 35 and 36 would look like
```
>>> x = [2.82999992, 2.92000008, 3.00000000]
>>> print([y*12 for y in x])
[33.95999904, 35.04000096, 36.0]
```
and model step 34 had been omitted in integer comparison.

This PR rounds to the closest integer, and omits therefore the problem.