### PR TITLE
fixing mis-assignment of run-index vs defined-index

### DIFF
--- a/src/common/drydep.f90
+++ b/src/common/drydep.f90
@@ -188,7 +188,7 @@ subroutine drydep2(tstep, part)
 !> particle
   type(Particle), intent(inout) :: part
 
-  integer :: m,i,j,mm,mo
+  integer :: m,i,j,mo
   real :: deprate, dep
   real, parameter :: h = 30.0  ! [m]
   real, parameter :: vd_gas = 0.008  ! [m/s]
@@ -215,7 +215,7 @@ subroutine drydep2(tstep, part)
     i = hres_pos(part%x)
     j = hres_pos(part%y)
     mo = def_comp(m)%to_output
-  !$OMP atomic
+    !$OMP atomic
     depdry(i,j,mo) = depdry(i,j,mo) + dble(dep)
   end if
 end subroutine drydep2
@@ -548,7 +548,7 @@ subroutine drydep_nonconstant_vd(tstep, vd, part)
   if (def_comp(m)%kdrydep == 1 .and. part%z > 0.996) then
 
     mm = def_comp(m)%to_running
-    
+
     i = nint(part%x)
     j = nint(part%y)
 

--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -515,9 +515,9 @@ PROGRAM bsnap
       write (iulog, *) 'component no:  ', n
       write (iulog, *) 'compname:   ', def_comp(m)%compname
       write (iulog, *) '  field id:   ', def_comp(m)%idcomp
+      write (iulog, *) '  output_id:  ', def_comp(m)%to_output
       write (iulog, *) '  output:     ', output_component(def_comp(m)%to_output)%name
       write (iulog, *) '  output-defs:', output_component(def_comp(m)%to_output)%to_defined
-      write (iulog, *) '  output_id:  ', def_comp(m)%to_output
       write (iulog, *) '  kdrydep:    ', def_comp(m)%kdrydep
       write (iulog, *) '  drydephgt:  ', def_comp(m)%drydephgt
       write (iulog, *) '  drydeprat:  ', def_comp(m)%drydeprat
@@ -2174,7 +2174,7 @@ contains
     do m = 1, ncomp
       k = 0
       do i = 1, size(output_component)
-        if (output_component(i)%name == def_comp(m)%output_name) k = i
+        if (output_component(i)%name == run_comp(m)%defined%output_name) k = i
       end do
       if (k == 0) then
         ! initialize new output_component
@@ -2187,7 +2187,7 @@ contains
           output_component(:size(temp_comp)) = temp_comp(:)
         end block
         allocate(output_component(k)%to_defined(0))
-        output_component(k)%name = def_comp(m)%output_name
+        output_component(k)%name = run_comp(m)%defined%output_name
       end if
       ! add m to the output-component(k) (might be new)
       block
@@ -2197,11 +2197,11 @@ contains
         call move_alloc(from=output_component(k)%to_defined, to=temp_defs)
         allocate(output_component(k)%to_defined(s+1))
         output_component(k)%to_defined(:s) = temp_defs
-        output_component(k)%to_defined(s+1) = m
+        output_component(k)%to_defined(s+1) = run_comp(m)%to_defined
       end block
       if (def_comp(m)%kwetdep > 0) output_component(k)%has_wetdep = .true.
       if (def_comp(m)%kdrydep > 0) output_component(k)%has_drydep = .true.
-      def_comp(m)%to_output = k
+      run_comp(m)%defined%to_output = k
     end do
     nocomp = size(output_component)
 


### PR DESCRIPTION
A memory-leak was caused when SNAP was run with less released components than defined components, in the case of the current exercise, only Cs-137 and I-131 was released, while also Xe-133 was defined (by default).

A mis-assignment between the output for run-time components versus output for the defined components caused then several memory-accesses at undefined places and finally a crash in SNAP.