### PR TITLE
Fix volcano height log + coord parsing 

### DIFF
--- a/utils/SnapPy/Snappy/EEMEP/Controller.py
+++ b/utils/SnapPy/Snappy/EEMEP/Controller.py
@@ -401,7 +401,7 @@ class Controller:
                 f"Negative cloud height {cheight / 1000.:.2f}! Please check ash cloud."
             )
         self.write_log(
-            f"Ash cloud height measured from volcano: {cheight / 1000.0:.2f} km, rate: {rate:.0f} kg/s, volcano height: {latf:.2f} km."
+            f"Ash cloud height measured from volcano: {cheight / 1000.0:.2f} km, rate: {rate:.0f} kg/s, volcano height: {altf / 1000.:.2f} km."
         )
 
         # Abort if errors

--- a/utils/SnapPy/Snappy/Utils.py
+++ b/utils/SnapPy/Snappy/Utils.py
@@ -54,8 +54,9 @@ def _parseLLNumber(llstr):
     if len(llstr) > 0 and llstr[0].upper() in "NSEW":
         character = llstr[0]
         num = llstr[1:].strip()
-        degrees = num[:2]
-        minutes = num[2:]
+        # e.g. Reventador PSN: S0004 W07739
+        degrees = num[:-2]
+        minutes = num[-2:]
 
         number = float(degrees) + float(minutes) / 60.0
         return number, character.upper()

--- a/utils/SnapPy/Snappy/Utils.py
+++ b/utils/SnapPy/Snappy/Utils.py
@@ -54,7 +54,6 @@ def _parseLLNumber(llstr):
     if len(llstr) > 0 and llstr[0].upper() in "NSEW":
         character = llstr[0]
         num = llstr[1:].strip()
-        # e.g. Reventador PSN: S0004 W07739
         degrees = num[:-2]
         minutes = num[-2:]
 
@@ -133,6 +132,8 @@ class IsLatLonTests(unittest.TestCase):
         self.assertAlmostEqual(parseLat("60°5'5\"N"), 60.084722, msg="parseLat(\"60°5'5\"N\")", delta=1e-3)
         self.assertAlmostEqual(parseLat("8°20′2+″S+"), -8.333, msg="parseLat(\"8°20′27″S \")", delta=1e-3)
         self.assertAlmostEqual(parseLat("N6451"), 64.85, msg="parseLat(\"N6451 \")", delta=1e-3)
+        # Reventador PSN: S0004 W07739
+        self.assertAlmostEqual(parseLat("S0004"), -0.0666, msg="parseLat(\"S0004\")", delta=1e-3)
         self.assertRaises(ValueError, parseLat, "195")
 
     def testParseLon(self):
@@ -145,6 +146,8 @@ class IsLatLonTests(unittest.TestCase):
         self.assertAlmostEqual(parseLon("3 °5' 3\" W"), -3.0841, msg="parseLon(\"3 °5' 3\" W\")", delta=1e-3)
         self.assertAlmostEqual(parseLon("10°4'W"), -10.06666, msg="parseLon(\"10°4'W\")", delta=1e-3)
         self.assertAlmostEqual(parseLon("W01947"), -19.7833333, msg="parseLon(\"W01947\")", delta=1e-3)
+        # Reventador PSN: S0004 W07739
+        self.assertAlmostEqual(parseLon("W07739"), -77.65, msg="parseLon(\"W07739\")", delta=1e-3)
         self.assertRaises(ValueError, parseLon, "370")
 
 


### PR DESCRIPTION
small tweaks fixing issues encountered while running with coordinates copy-pasted from advisories like this https://ds.data.jma.go.jp/svd/vaac/data/TextData/2025/20250707_28209000_0056_Text.html or this https://www.ospo.noaa.gov/VAAC/ARCH25/REVE/2025B151220.html