### PR TITLE
Make met names overridable

### DIFF
--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -1762,6 +1762,14 @@ contains
         end if
         call init_meteo_params(nctype, ierror)
         if (ierror /= 0) goto 12
+#if defined(SNAP_EXPERIMENTAL)
+      case ('grid.nctype.leaf_area_index')
+        if (.not. has_value) goto 12
+        read(cinput(pname_start:pname_end), *, err=12) met_params%leaf_area_index
+      case ('grid.nctype.z0')
+        if (.not. has_value) goto 12
+        read(cinput(pname_start:pname_end), *, err=12) met_params%z0
+#endif
       case ('grid.size')
         !..grid.size=<nx,ny>
         if (.not. has_value) goto 12


### PR DESCRIPTION
Within the AROME products there might be inconsistencies in the name of the variables. I propose the ability to override certain names but still being able to default from an nctype