### PR TITLE
adding so2 to snap-ash runs

### DIFF
--- a/utils/SnapPy/Snappy/EEMEP/SixHourMax.py
+++ b/utils/SnapPy/Snappy/EEMEP/SixHourMax.py
@@ -51,6 +51,8 @@ i.e. calculate the 6hour mean of the last six hours (running) (average also the 
     PEAK_TO_MEAN_CALIBRATION = 1.
     SNAP_ASH_CONC_PATTERN = re.compile(r"ASH(_\d+)?_concentration_ml")
     SNAP_ASH_COL_PATTERN = re.compile(r"ASH(_\d+)?_column_concentration")
+    SNAP_SO2_CONC_PATTERN = re.compile(r"SO2_concentration_ml")
+    SNAP_SO2_COL_NAME = "SO2_column_concentration"
 
     @classmethod
     def detect_ash_model(cls, nc: netCDF4.Dataset) -> str:
@@ -155,6 +157,16 @@ i.e. calculate the 6hour mean of the last six hours (running) (average also the 
             self.nc.sync()
         return
 
+    def _snap_rename_total_so2_column(self) -> None:
+        if self.model != 'snap':
+            return
+        if self.SNAP_SO2_COL_NAME in self.nc.variables:
+            self.nc.renameVariable(self.SNAP_SO2_COL_NAME, "COLUMN_SO2_kmax")
+            self.nc["COLUMN_SO2_kmax"].units = self.nc["COLUMN_SO2_kmax"].units.replace('Bq', 'g')
+            self.nc.sync()
+        return
+
+
     def __init__(self, nc):
         '''Initialize with Dataset nc'''
         logger.info("Adding 6hour max to nc-file")
@@ -224,6 +236,7 @@ i.e. calculate the 6hour mean of the last six hours (running) (average also the 
             nc.sync()
 
         self._snap_add_total_ash_column()
+        self._snap_rename_total_so2_column()
         return
 
 if __name__ == '__main__':

--- a/utils/SnapPy/Snappy/EEMEP/resources/snapash.input_nrpa_ec_0p1.tmpl
+++ b/utils/SnapPy/Snappy/EEMEP/resources/snapash.input_nrpa_ec_0p1.tmpl
@@ -24,7 +24,7 @@ STEP.HOUR.OUTPUT.FIELDS= 1
 
 RANDOM.WALK.ON
 BOUNDARY.LAYER.FULL.MIX.OFF
-DRY.DEPOSITION.NEW
+DRY.DEPOSITION.SCHEME=NEW
 WET.DEPOSITION.VERSION = 2
 
 * reduces about 10% of model-particles by redistributing the 0.001% smallest ones within the plume
@@ -77,7 +77,7 @@ TIME.RELEASE.PROFILE.STEPS
 RELEASE.HEIGHTLOWER.M = {lowerlist}
 RELEASE.HEIGHTUPPER.M = {upperlist}
 RELEASE.HEIGHTRADIUS.M = {radiuslist}
-RELEASE.COMPONENTS= 'ASH_1', 'ASH_2', 'ASH_3', 'ASH_4', 'ASH_5', 'ASH_6'
+RELEASE.COMPONENTS= 'ASH_1', 'ASH_2', 'ASH_3', 'ASH_4', 'ASH_5', 'ASH_6', 'SO2'
 
 ***List of components
 COMPONENT= ASH_1
@@ -133,3 +133,16 @@ RADIOACTIVE.DECAY.OFF
 RADIUS.MICROMETER=27.39
 * VAAC London Tephra Density: 2.3g/cm3 based on Sparks et al, 1997
 DENSITY.G/CM3=2.3
+
+COMPONENT= SO2
+* no dry-dep for gases
+DRY.DEP.OFF
+WET.DEP.ON
+RADIUS.MICROMETER=0.05
+DENSITY.G/CM3=0.001
+GRAVITY.FIXED.M/S=0.00001
+* here: chemical decay to SO4
+RADIOACTIVE.DECAY.ON
+* decay-rate SO2 -> SO4, 12% / hour =~ decay-rate 3.5e-5
+HALF.LIFETIME.HOURS= 5.5
+


### PR DESCRIPTION
Adding so2 to snap-ash runs similar to eemep, e.g. 0.1Tg/hr over the first two hours.

so2 is emitted over the complete ash-column, i.e. not restricted to 2km as in eemep. To see a 2km release, lowering the ash-height to wil lower the so2 height, too.

Decay-rate of SO2 -> SO4 is 3.5e-5, as in Hysplit and eEMEP, which is a halflife of ~5.5hr. This is slightly more than 10%, e.g. ~12% per hour.