### PR TITLE
testing vgravtables and using vgrav in ddep-emmerson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,11 +84,18 @@ Snappy.egg-info
 
 /src/test/testDateCalc
 /src/test/test_array_utils
+/src/test/bsnap_naccident
+/src/test/testGravSettling
 /src/test/find_parameters_fi_test
 /src/test/snap_batch_copy.F90
 
 
 src/test/snap_testdata
+src/test/data/snap.log
+src/test/data/snap.nc
+src/test/data/snap_ecemep.nc
+src/test/data/snap_meps_fimex.nc
+src/test/data/snap_meps_fimex.log
 
 docs/html
 docs/latex

--- a/src/common/drydep.f90
+++ b/src/common/drydep.f90
@@ -306,7 +306,7 @@ pure elemental subroutine drydep_emerson_vd(surface_pressure, t2m, ustar, raero,
     vd_dep)
   use datetime, only: datetime_t
   use snapparML, only: defined_component
-  use vgravtablesML, only: vgrav, vgrav_zanetti
+  use vgravtablesML, only: vgrav
   !> In hPa
   real, intent(in) :: surface_pressure
   real, intent(in) :: t2m
@@ -324,10 +324,9 @@ pure elemental subroutine drydep_emerson_vd(surface_pressure, t2m, ustar, raero,
   real(real64) :: fac1, cslip, bdiff, sc, EB, EIM, EIN, stokes
   integer(int16) :: Apar
 
-  !vs = vgrav(component%to_running, surface_pressure/100., t2m)
 
   diam = 2*component%radiusmym*1e-6
-  vs = vgrav_zanetti(real(diam * 1e6), real(component%densitygcm3), surface_pressure / 100, t2m) / 1e2
+  vs = vgrav(component%to_running, surface_pressure/100., t2m)
 
   fac1 = -0.55 * diam / lambda
   ! Cunningham slip factor

--- a/src/common/vgravtables.f90
+++ b/src/common/vgravtables.f90
@@ -34,7 +34,7 @@ module vgravtablesML
   real, parameter, private :: pincrvg = 1200./float(numpresvg-1)
   real, parameter, private :: pbasevg = 0. - pincrvg
 
-  public :: vgravtables_init, vgrav, vgrav_zanetti
+  public :: vgravtables_init, vgrav, vgrav_iter ! vgrav_iter only exposed for testing
 
   contains
 
@@ -225,6 +225,19 @@ end subroutine
 
   end function vgrav
 
+!< computed and iterated gravitational settling velocity in m/s
+elemental real function  vgrav_iter(dp, rp, p, t)
+  real, intent(in) :: dp !< particle size (diameter) in micro meters
+  real, intent(in) :: rp !< particle density in g/cm3
+  real, intent(in) :: p !< atmospheric pressure in hPa
+  real, intent(in) :: t !< temperature of the air in K
+  real :: vg, u0 !< vg according to Stokes law in cm/s
+
+  u0 =  vgrav_zanetti(dp,rp,p,t)
+  call iter(vg,u0,dp,rp,p,t)
+  vgrav_iter=vg*0.01 ! cm/s -> m/s
+end function vgrav_iter
+
 !>  program for calculating gravitational setling velocity for particles
 !>  according to Zannetti (1990).
 !>
@@ -247,7 +260,7 @@ end subroutine
   end function vgrav_zanetti
 
 !>  iteration procedure for calculating vg
-subroutine iter(vg,u0,dp,rp,p,t)
+pure subroutine iter(vg,u0,dp,rp,p,t)
   real, intent(out) :: vg !< computed gravitational settling velocity in cm/s
   real, intent(in) :: u0 !< vg according to Stokes law in cm/s
   real, intent(in) :: dp !< particle size (diameter) in micro meters
@@ -291,6 +304,7 @@ subroutine iter(vg,u0,dp,rp,p,t)
 
   return
 end subroutine iter
+
 
 !>  function for calculating density of the air depending on
 !>  temperature and pressure. According to RAFF (1999).

--- a/src/test/.gitignore
+++ b/src/test/.gitignore
@@ -1,6 +1,0 @@
-bsnap_naccident
-data/snap.log
-data/snap.nc
-data/snap_ecemep.nc
-data/snap_meps_fimex.nc
-data/snap_meps_fimex.log

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -23,8 +23,9 @@ snap_testdata/%.nc :
 	mkdir -p snap_testdata
 	curl --fail https://thredds.met.no/thredds/fileServer/metusers/heikok/$@ -o $@
 
-test: testDateCalc test_array_utils find_parameters_fi_test bsnap_naccident $(TESTFILES)
+test: testDateCalc testGravSettling test_array_utils find_parameters_fi_test bsnap_naccident $(TESTFILES)
 	./testDateCalc && \
+	./testGravSettling && \
 	./test_array_utils && \
 	./find_parameters_fi_test snap_testdata/meteo20200415_00_ringhals.nc u_wind && \
 	./find_parameters_fi_test snap_testdata/meps_det_2_5km_20200316T00Z_ringhals.nc x_wind_ml && \
@@ -41,6 +42,9 @@ find_parameters_fi_test: find_parameters_fi_test.o $(MODELOBJ)
 testDateCalc: testDateCalc.o $(MODELOBJ)
 	${F77} $(F77FLAGS) $< $(MODELOBJ) $(BLIBS) -o $@
 
+testGravSettling: testGravSettling.o $(MODELOBJ)
+	${F77} $(F77FLAGS) $(MODELOBJ) $< $(BLIBS) -o $@
+
 test_array_utils: test_array_utils.o $(MODELOBJ)
 	${F77} $(F77FLAGS) $(MODELOBJ) $< $(BLIBS) -o $@
 
@@ -56,6 +60,9 @@ find_parameters_fi_test.o: find_parameters_fi_test.f90 $(MODELOBJ)
 	${F77} -c ${F77FLAGS} $(INCLUDES) $<
 
 testDateCalc.o: testDateCalc.f90 $(MODELOBJ)
+	${F77} -c ${F77FLAGS} $(INCLUDES) $<
+
+testGravSettling.o: testGravSettling.f90 $(MODELOBJ)
 	${F77} -c ${F77FLAGS} $(INCLUDES) $<
 
 test_array_utils.o: test_array_utils.f90 $(MODELOBJ)

--- a/src/test/testGravSettling.f90
+++ b/src/test/testGravSettling.f90
@@ -1,0 +1,73 @@
+program testGravSettling
+  use vgravtablesML, only : vgravtables_init, vgrav, vgrav_iter
+  use snapparML, only: def_comp, push_down_dcomp, defined_component, GRAV_TYPE_COMPUTED, &
+    ncomp, run_comp
+  implicit none
+
+  integer :: i, t , p
+  real(8) :: vg1, vg2
+  type(defined_component), pointer :: d_comp
+
+  ! define 4 components 1,10,50,100 µm radius
+  ncomp = 4
+  call push_down_dcomp(def_comp, top=d_comp)
+  d_comp%compname = "Ra100"
+  d_comp%output_name = d_comp%compname ! default
+  d_comp%radiusmym = 100.0
+  d_comp%densitygcm3 = 2.3
+  d_comp%grav_type = GRAV_TYPE_COMPUTED
+
+  call push_down_dcomp(def_comp, top=d_comp)
+  d_comp%compname = "Ra50"
+  d_comp%output_name = d_comp%compname ! default
+  d_comp%radiusmym = 50.0
+  d_comp%densitygcm3 = 2.3
+  d_comp%grav_type = GRAV_TYPE_COMPUTED
+
+  call push_down_dcomp(def_comp, top=d_comp)
+  d_comp%compname = "Ra10"
+  d_comp%output_name = d_comp%compname ! default
+  d_comp%radiusmym = 10.0
+  d_comp%densitygcm3 = 2.3
+  d_comp%grav_type = GRAV_TYPE_COMPUTED
+
+  call push_down_dcomp(def_comp, top=d_comp)
+  d_comp%compname = "Ra1"
+  d_comp%output_name = d_comp%compname ! default
+  d_comp%radiusmym = 1.0
+  d_comp%densitygcm3 = 2.3
+  d_comp%grav_type = GRAV_TYPE_COMPUTED
+
+
+  allocate (run_comp(ncomp))
+  do i = 1, ncomp
+    run_comp(i)%to_defined = i
+    run_comp(i)%defined => def_comp(i)
+    def_comp(i)%to_running = i
+  end do
+
+  call vgravtables_init()
+  do i = 1, ncomp
+    print *, "Component ", i, ": ", def_comp(i)%compname, ", radius ", &
+      def_comp(i)%radiusmym, " µm, density ", def_comp(i)%densitygcm3, " g/cm3"
+    print *, 2*def_comp(i)%radiusmym, "µm diam, P=1013.25hPa, T=300K:"
+    print *, 'Tabulated Gravitational settling,', vgrav(i, 1013.25, 300.0), "m/s"
+    print *, 'Iterated gravitational settling:', &
+      vgrav_iter(2*def_comp(i)%radiusmym, def_comp(i)%densitygcm3, 1013.25, 300.0), "m/s"
+  end do
+
+  ! ensure that tabulated values are within 1% of iterated values
+  do i = 1, ncomp
+    do p = 100, 1100, 1 ! hPa
+      do t = 200, 350, 1 ! K
+        vg1 = vgrav(i, real(p), real(t))
+        vg2 = vgrav_iter(2*def_comp(i)%radiusmym, def_comp(i)%densitygcm3, real(p), real(t))
+        if ( abs( vg1 - vg2 ) / vg2 > 0.01 ) then
+          print *, "Error: Tabulated and iterated gravitational settling differ by more than 1% for component ", i, &
+            " at p=", p, " hPa, t=", t, " K: ", vg1, " vs ", vg2
+          stop 1
+        end if
+      end do
+    end do
+  end do
+end program testGravSettling


### PR DESCRIPTION
This MR tests the tabulated vgrav function to be within 1% of the iterated gravitational settling velocity.

It uses also the vgrav rather than the stokes/zanetti gravitational settling velocity for the emmerson dry deposition. vgrav is for large particles (100µm) about 50% of gravitational settling velocity of pure stokes due to cunningham drag factor.

fixes #178 