### PR TITLE
allow usage of last (_03.nc) day

### DIFF
--- a/utils/SnapPy/Snappy/EEMEP/Resources.py
+++ b/utils/SnapPy/Snappy/EEMEP/Resources.py
@@ -349,7 +349,7 @@ class Resources(ResourcesCommon):
             assert isinstance(
                 startday, datetime
             ), "getECMeteorology: fixed_run must be 'best' or YYYY-MM-DD_HH"
-            for offset in range(0, math.ceil(run_hours / 24.0)):
+            for offset in range(4):
                 file = self.EC_FILE_PATTERN.format(
                     dayoffset=offset,
                     UTC=startday.hour,


### PR DESCRIPTION
allow usage of last (_03.nc) day -file when running with a specific NWP-forecast.

closes #196 