### PR TITLE
Use x86-64-v3

### DIFF
--- a/debian.noble/ubuntuPackage.mk
+++ b/debian.noble/ubuntuPackage.mk
@@ -4,7 +4,7 @@
 F77 = gfortran
 
 F77DEBUGFLAGS= -ffpe-trap=invalid,zero,overflow -fbounds-check
-F77FLAGS=-DVERSION=\"$(VERSION)\" -O2 -ftree-vectorize -fno-math-errno -g -mavx2 -mfma -Wall -Wextra -fimplicit-none -fmodule-private -Wno-conversion
+F77FLAGS=-DVERSION=\"$(VERSION)\" -O2 -ftree-vectorize -fno-math-errno -g -march=x86-64-v3 -Wall -Wextra -fimplicit-none -fmodule-private -Wno-conversion
 ifdef SNAP_DEBUG_CHECKS
   F77FLAGS+=$(F77DEBUGFLAGS)
 endif

--- a/src/gcc_pkgconfig.mk
+++ b/src/gcc_pkgconfig.mk
@@ -5,7 +5,7 @@ F77 = gfortran
 
 F77FPEFLAGS= -ffpe-trap=invalid,zero,overflow -fno-openmp
 F77BOUNDFLAGS= -fbounds-check -fno-openmp
-F77FLAGS=-DVERSION=\"$(VERSION)\" -O2 -ftree-vectorize -fno-math-errno -fopenmp -g -mavx2 -mfma -Wall -Wextra -fimplicit-none -fmodule-private -Wno-conversion -Wno-compare-reals
+F77FLAGS=-DVERSION=\"$(VERSION)\" -O2 -ftree-vectorize -fno-math-errno -fopenmp -g -march=x86-64-v3 -Wall -Wextra -fimplicit-none -fmodule-private -Wno-conversion -Wno-compare-reals
 # -flto gives only 2-4% speedup, not using since more difficult debug and optimize steps
 ifdef SNAP_DEBUG_CHECKS
   F77FLAGS+=$(F77BOUNDFLAGS) $(F77FPEFLAGS)

--- a/src/rh8conda.mk
+++ b/src/rh8conda.mk
@@ -13,9 +13,9 @@
 #      -ftree-vectorizer-verbose=2
 #-ffpe-trap=invalid,zero,overflow
 #F77FLAGS=-O2 -g -ftree-vectorize -fno-math-errno -ffpe-trap=invalid,zero,overflow -g -mavx -fopt-info-optimized-vec #-fopenmp
-F77FLAGS=-DVERSION=\"$(VERSION)\" -O2 -g -mavx2 -ftree-vectorize -fno-math-errno -Wall -Wextra -fimplicit-none -fmodule-private
-CXXFLAGS=-O2 -mavx2 -ftree-vectorize -fno-math-errno -Wall -Wextra
-CCFLAGS=-O2 -mavx2 -ftree-vectorize -fno-math-errno -Wall -Wextra
+F77FLAGS=-DVERSION=\"$(VERSION)\" -O2 -g -march=x86-64-v3 -ftree-vectorize -fno-math-errno -Wall -Wextra -fimplicit-none -fmodule-private
+CXXFLAGS=-O2 -march=x86-64-v3 -ftree-vectorize -fno-math-errno -Wall -Wextra
+CCFLAGS=-O2 -march=x86-64-v3 -ftree-vectorize -fno-math-errno -Wall -Wextra
 
 LDFLAGS=
 


### PR DESCRIPTION
Use the newer and cleaner x86 ABI levels as described here: https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels

x86-64-v3 is the equivalent of intel haswell (2013 and newer) and amd excavator (2015 and newer), and covers avx2/fma.

Next step will be x86-64-v4 intel skylake (2016) and amd zen4 (2022), supporting among others avx512. Since we still have to support some older amd nodes, we will have to wait with this. (Only the sm* nodes have zen4).