### PR TITLE
fix interpolation for landuse for all runners, not only SnapPy

### DIFF
--- a/utils/SnapPy/Snappy/Resources.py
+++ b/utils/SnapPy/Snappy/Resources.py
@@ -453,6 +453,11 @@ GRAVITY.FIXED.M/S=0.0002
             )
         elif metmodel == MetModel.EC0p1Europe:
             # uses the same as global, with interpolation
+            if "FIMEX.INTERPOLATION" not in interpolation.upper():
+                # must have interpolation, use default EC0p1Europe unless given otherwise
+                latN, lonW, latS, lonE = 85, -20, 30, 50
+                gridRes = 0.1
+                interpolation += f"\nFIMEX.INTERPOLATION=nearest|+proj=latlon +R=6371000 +no_defs|{lonW},{lonW + gridRes},...,{lonE}|{latS},{latS + gridRes},...,{latN}|degree\n"
             largest_landfraction_file = os.path.join(
                 self.directory, "landfractions", "largestLandFraction_EC0p1Global.nc"
             )

--- a/utils/SnapPy/Snappy/SnapController.py
+++ b/utils/SnapPy/Snappy/SnapController.py
@@ -496,16 +496,8 @@ STEP.HOUR.OUTPUT.FIELDS= 3
                     f"no {qDict['metmodel']}  met-files found for {startDT}, runtime {qDict['runTime']}"
                 )
                 return
-
-            if qDict["metmodel"] == MetModel.EC0p1Europe:
-                latN, lonW, latS, lonE = 85, -20, 30, 50
-                gridRes = 0.1
-                interpol = f"FIMEX.INTERPOLATION=nearest|+proj=latlon +R=6371000 +no_defs|{lonW},{lonW + gridRes},...,{lonE}|{latS},{latS + gridRes},...,{latN}|degree\n"
-            else:
-                interpol = ""
-
             with open(os.path.join(self.lastOutputDir, "snap.input"), "a") as fh:
-                fh.write(self.res.getSnapInputMetDefinitions(qDict["metmodel"], files, interpolation=interpol))
+                fh.write(self.res.getSnapInputMetDefinitions(qDict["metmodel"], files))
             self._snap_model_run()
         else:
             self.write_log(f"unsupported MET-model '{qDict['metmodel']}' requested")


### PR DESCRIPTION
interpolation was only added for ec0p1europe when run from SnapPy with the SnapController. Other command-line usages, like snap4rimsterm or snapRunnerNpp did not have set interpolation. Moving therefore interpolation from SnapController to Resources.