### PR TITLE
Asynoptic time fix

### DIFF
--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -640,8 +640,6 @@ PROGRAM bsnap
       release_positions(irelpos)%grid_y = y(1)
     end block
 
-    ! start time loop
-    itimei = time_start
     npartmax = 0
 #ifdef _OPENMP
     ! both task and inner parallel do loops, so need 2 levels of parallelism
@@ -663,8 +661,14 @@ PROGRAM bsnap
 
       if (.not. use_async_io .or. istep == 0) then
         if (next_input_step == istep .and. nhleft > 0) then
-          itimei = time_file
           call input_timer%start()
+          if (istep == 0) then
+            ! start time loop
+            itimei = time_start
+          else
+            ! initial time to start next timestep is the time of the current file
+            itimei = time_file
+          end if
           if (.not. use_async_io) then
             ! move all u2, v2, etc fields to u1, v1, etc before reading new fields to u2, v2, etc
             call swap_fields_before_reading()

--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -705,7 +705,12 @@ PROGRAM bsnap
           end if
           ! just keep reading from the last timestep, no interpolation needed
           call swap_fields_after_reading()
-          dur = time_file - itimei
+          if (istep == 0) then
+            dur = time_file - time_start
+          else
+            ! itimei is the current files timestep
+            dur = time_file - itimei
+          end if
           ihdiff = dur%hours
           tf1 = 0.
           tf2 = 3600.*ihdiff

--- a/src/common/snap.F90
+++ b/src/common/snap.F90
@@ -640,6 +640,8 @@ PROGRAM bsnap
       release_positions(irelpos)%grid_y = y(1)
     end block
 
+    ! start time loop
+    itimei = time_start
     npartmax = 0
 #ifdef _OPENMP
     ! both task and inner parallel do loops, so need 2 levels of parallelism
@@ -662,13 +664,8 @@ PROGRAM bsnap
       if (.not. use_async_io .or. istep == 0) then
         if (next_input_step == istep .and. nhleft > 0) then
           call input_timer%start()
-          if (istep == 0) then
-            ! start time loop
-            itimei = time_start
-          else
-            ! initial time to start next timestep is the time of the current file
-            itimei = time_file
-          end if
+          ! initial time to read next timestep is the time of the current file
+          itimei = time_file
           if (.not. use_async_io) then
             ! move all u2, v2, etc fields to u1, v1, etc before reading new fields to u2, v2, etc
             call swap_fields_before_reading()
@@ -678,7 +675,13 @@ PROGRAM bsnap
           write (error_unit, fmt="('input data: ',i4,3i3.2)") time_file
           call input_timer%stop_and_log()
 
-          dur = time_file - itimei
+          ! duration to next read
+          if (istep == 0) then
+            dur = time_file - time_start
+          else
+            ! itimei is the current files timestep
+            dur = time_file - itimei
+          end if
           ihdiff = dur%hours
           tf1 = 0.
           tf2 = 3600.*ihdiff


### PR DESCRIPTION
SNAP runs not starting together with the meteorological datasets would create a time-interpolation offset with the meteorology starting with the third meteorological field to be read.

When a run does not start at the meteorology-timestep (3hourly), but lets say x+1, the first two meteo-fields (x, x+3) are read in correctly, but the next fields is not read at x+6 but at x+1+6, creating an additional 1h offset.

This was only visible on the precipitation output, which should for 3hourly meteorology and 1hourly output look in the output 01:00 to 03:00 look like 03:00 meteo-input (i.e. accumulated from 00:01-03:00), 04:00 to 06:00 should look like 06:00 meteo-input, ...

This error was most likely introduced in da8d2af in December 2021.
 
